### PR TITLE
Correct the spelling of "Clojure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ If you want to contribute to this list (please do), send me a pull request or co
 * [ecogg](https://code.google.com/p/encog-cpp/)
 * [shark](http://image.diku.dk/shark/sphinx_pages/build/html/index.html)
 
-## Closure
+## Clojure
 
 #### General-Purpose Machine Learning
 
-* [Closure Toolbox](http://www.clojure-toolbox.com) - A categorised directory of libraries and tools for Clojure
+* [Clojure Toolbox](http://www.clojure-toolbox.com) - A categorised directory of libraries and tools for Clojure
 
 ## Go
 


### PR DESCRIPTION
Closure != Clojure.
