### PR TITLE
Add SimpleCV for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ on MNIST digits[DEEP LEARNING]
 
 ## Python
 
+#### Computer Vision
+
+* [SimpleCV](http://simplecv.org/) - An open source computer vision framework that gives access to several high-powered computer vision libraries, such as OpenCV. Written on Python and runs on Mac, Windows, and Ubuntu Linux.
+
 #### Natural Language Processing
 
 * [NLTK](http://www.nltk.org/) - A leading platform for building Python programs to work with human language data.


### PR DESCRIPTION
I've used SimpleCV for a few hackathon projects and found it very easy to use. It provides a simple interface for a fair amount of computer vision tasks. I found pip-installing it to be much less painful than going through the install process for OpenCV.
