### PR TITLE
Add SKLL to Python general purpose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ on MNIST digits[DEEP LEARNING]
 * [breze](https://github.com/breze-no-salt/breze) - Theano based library for deep and recurrent neural networks
 * [pyhsmm](https://github.com/mattjj/pyhsmm) - library for approximate unsupervised inference in Bayesian Hidden Markov Models (HMMs) and explicit-duration Hidden semi-Markov Models (HSMMs), focusing on the Bayesian Nonparametric extensions, the HDP-HMM and HDP-HSMM, mostly with weak-limit approximations.
 * [mrjob](https://pythonhosted.org/mrjob/) - A library to let Python program run on Hadoop.
+* [SKLL](https://github.com/EducationalTestingService/skll) - A wrapper around scikit-learn that makes it simpler to conduct experiments.
 
 <a name="python-data-analysis" />
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
[SciKit-Learn Laboratory (SKLL)](https://github.com/EducationalTestingService/skll) is a Python package that makes it simpler to run batches of experiments with scikit-learn. It also interfaces with [GridMap](https://github.com/EducationalTestingService/gridmap) to allow you to automatically run a bunch of experiments in parallel on a cluster managed by DRMAA-compatible system like Grid Engine.
