### PR TITLE
CNN-RNN for 3D Object Classification by Socher et al.added

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ For a list of free machine learning books available for download, go [here](http
 * [Training a deep autoencoder or a classifier
 on MNIST digits](http://www.cs.toronto.edu/~hinton/MatlabForSciencePaper.html) - Training a deep autoencoder or a classifier
 on MNIST digits[DEEP LEARNING]
+* [Convolutional-Recursive Deep Learning for 3D Object Classification](http://www.socher.org/index.php/Main/Convolutional-RecursiveDeepLearningFor3DObjectClassification) - Convolutional-Recursive Deep Learning for 3D Object Classification[DEEP LEARNING]
 * [t-Distributed Stochastic Neighbor Embedding](http://homepage.tudelft.nl/19j49/t-SNE.html) - t-Distributed Stochastic Neighbor Embedding (t-SNE) is a (prize-winning) technique for dimensionality reduction that is particularly well suited for the visualization of high-dimensional datasets.
 * [Spider](http://people.kyb.tuebingen.mpg.de/spider/) - The spider is intended to be a complete object orientated environment for machine learning in Matlab.
 * [LibSVM](http://www.csie.ntu.edu.tw/~cjlin/libsvm/#matlab) - A Library for Support Vector Machines


### PR DESCRIPTION
Convolutional-Recursive Deep Learning for 3D Object Classification by Richard Socher, Brody Huval, Bharath Bhat, Christopher D. Manning, Andrew Y. Ng, they introduce a model based on a combination of convolutional and recursive neural networks (CNN and RNN) for learning features and classifying RGB-D images. The dataset used to train the network can be download [here](http://rgbd-dataset.cs.washington.edu/).