### PR TITLE
added spammy to python-nlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ on MNIST digits[DEEP LEARNING]
 * [YAlign](https://github.com/machinalis/yalign) - A sentence aligner, a friendly tool for extracting parallel sentences from comparable corpora.
 * [jieba](https://github.com/fxsjy/jieba#jieba-1) - Chinese Words Segmentation Utilities.
 * [SnowNLP](https://github.com/isnowfy/snownlp) - A library for processing Chinese text.
+* [spammy](https://github.com/prodicus/spammy) - A library for email Spam filtering built on top of nltk
 * [loso](https://github.com/victorlin/loso) - Another Chinese segmentation library.
 * [genius](https://github.com/duanhongyi/genius) - A Chinese segment base on Conditional Random Field.
 * [KoNLPy](http://konlpy.org) - A Python package for Korean natural language processing.


### PR DESCRIPTION
spammy is an intelligent spam filtering library which can trained extensively

Github link: https://github.com/prodicus/spammy

Software it powers: https://plino.herokuapp.com/