### PR TITLE
Add imbalanced-learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ on MNIST digits[DEEP LEARNING]
 * [Bolt](https://github.com/pprett/bolt) - Bolt Online Learning Toolbox
 * [CoverTree](https://github.com/patvarilly/CoverTree) - Python implementation of cover trees, near-drop-in replacement for scipy.spatial.kdtree
 * [nilearn](https://github.com/nilearn/nilearn) - Machine learning for NeuroImaging in Python
+* [imbalanced-learn](http://contrib.scikit-learn.org/imbalanced-learn/) - Python module to perform under sampling and over sampling with various techniques.
 * [Shogun](https://github.com/shogun-toolbox/shogun) - The Shogun Machine Learning Toolbox
 * [Pyevolve](https://github.com/perone/Pyevolve) - Genetic algorithm framework.
 * [Caffe](http://caffe.berkeleyvision.org)  - A deep learning framework developed with cleanliness, readability, and speed in mind.


### PR DESCRIPTION
Added imbalanced-learn to Python / General-Purpose Machine Learning

\[Awesome\] imbalanced-learn is part of [scikit-learn-contrib](https://github.com/scikit-learn-contrib), fully compatible with scikit-learn, and provides several techniques for handling imbalanced data, including under sampling, over sampling, and ensembling.

On the (github page)[https://github.com/scikit-learn-contrib/imbalanced-learn] it has (to this date):
- 359 Stargazers
- 125 Forks
- 30 Watchers