### PR TITLE
add scikit-plot as python visualization library

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ on MNIST digits[DEEP LEARNING]
 * [somoclu](https://github.com/peterwittek/somoclu) Massively parallel self-organizing maps: accelerate training on multicore CPUs, GPUs, and clusters, has python API.
 * [HDBScan](https://github.com/lmcinnes/hdbscan) - implementation of the hdbscan algorithm in Python - used for clustering
 * [visualize_ML](https://github.com/ayush1997/visualize_ML) - A python package for data exploration and data analysis.
+* [scikit-plot](https://github.com/reiinakano/scikit-plot) - A visualization library for quick and easy generation of common plots in data analysis and machine learning.
 
 <a name="python-misc" />
 #### Misc Scripts / iPython Notebooks / Codebases


### PR DESCRIPTION
Adds [scikit-plot](https://github.com/reiinakano/scikit-plot) to Python data visualization libraries