### PR TITLE
Remove auto_ml Python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,6 @@ on MNIST digits[DEEP LEARNING]
 
 <a name="python-general-purpose" />
 #### General-Purpose Machine Learning
-* [auto_ml](https://github.com/ClimbsRocks/auto_ml) - Automated machine learning pipelines for analytics and production. Handles some standard feature engineering, feature selection, model selection, model tuning, ensembling, and advanced scoring, in addition to logging output for analysts trying to understand their datasets.
 * [machine learning](https://github.com/jeff1evesque/machine-learning) - automated build consisting of a [web-interface](https://github.com/jeff1evesque/machine-learning#web-interface), and set of [programmatic-interface](https://github.com/jeff1evesque/machine-learning#programmatic-interface) API, for support vector machines.  Corresponding dataset(s) are stored into a SQL database, then generated model(s) used for prediction(s), are stored into a NoSQL datastore.
 * [XGBoost](https://github.com/dmlc/xgboost) - Python bindings for eXtreme Gradient Boosting (Tree) Library
 * [Bayesian Methods for Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers) - Book/iPython notebooks on Probabilistic Programming in Python


### PR DESCRIPTION
This library has merit like TPOT but isn't quite 'awesome'. There is really no stable release or API yet, and the documentation is very lacking.

For example, the documentation has a whole section on ensembling. [But randomly in the middle of the page, inside a code example](http://auto-ml.readthedocs.io/en/latest/ensembling.html), there is `NOTE: This feature is temporarily deprecated`

I guess everybody's definition of 'awesome' is a bit different, but I would expect libraries in this repo to be a bit more mature. It looks like the author is actively working on the project so my recommendation would be to review it for addition at a later date.