### PR TITLE
Add fuku-ml for Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ on MNIST digits[DEEP LEARNING]
 * [rgf_python](https://github.com/fukatani/rgf_python) - Python bindings for Regularized Greedy Forest (Tree) Library.
 * [gym](https://github.com/openai/gym) - OpenAI Gym is a toolkit for developing and comparing reinforcement learning algorithms.
 * [skbayes](https://github.com/AmazaspShumik/sklearn-bayes) - Python package for Bayesian Machine Learning with scikit-learn API
+* [fuku-ml](https://github.com/fukuball/fuku-ml) - Simple machine learning library, including Perceptron, Regression, Support Vector Machine, Decision Tree and more, it's easy to use and easy to learn for beginners.
 
 <a name="python-data-analysis" />
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Add fuku-ml for Python General-Purpose Machine Learning

Fuku-ml is a simple machine learning library, including Perceptron,
Regression, Support Vector Machine, Decision Tree and more, it's easy
to use and easy to learn for beginners.