### PR TITLE
Fix broken `a` tags breaking Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,23 +115,23 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 
 <!-- /MarkdownTOC -->
 
-<a name="apl" />
+<a name="apl"></a>
 ## APL
 
-<a name="apl-general-purpose" />
+<a name="apl-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [naive-apl](https://github.com/mattcunningham/naive-apl) - Naive Bayesian Classifier implementation in APL
 
-<a name="c" />
+<a name="c"></a>
 ## C
 
-<a name="c-general-purpose" />
+<a name="c-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [Darknet](https://github.com/pjreddie/darknet) - Darknet is an open source neural network framework written in C and CUDA. It is fast, easy to install, and supports CPU and GPU computation.
 * [Recommender](https://github.com/GHamrouni/Recommender) - A C library for product recommendations/suggestions using collaborative filtering (CF).
 * [Hybrid Recommender System](https://github.com/SeniorSA/hybrid-rs-trainner) - A hybrid recomender system based upon scikit-learn algorithms.
 
-<a name="c-cv" />
+<a name="c-cv"></a>
 #### Computer Vision
 
 * [CCV](https://github.com/liuliu/ccv) - C-based/Cached/Core Computer Vision Library, A Modern Computer Vision Library
@@ -140,10 +140,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 ### Speech Recognition
 * [HTK](http://htk.eng.cam.ac.uk/) -The Hidden Markov Model Toolkit (HTK) is a portable toolkit for building and manipulating hidden Markov models.
 
-<a name="cpp" />
+<a name="cpp"></a>
 ## C++
 
-<a name="cpp-cv" />
+<a name="cpp-cv"></a>
 #### Computer Vision
 
 * [DLib](http://dlib.net/imaging.html) - DLib has C++ and Python interfaces for face detection and training general object detectors.
@@ -151,7 +151,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [OpenCV](http://opencv.org) - OpenCV has C++, C, Python, Java and MATLAB interfaces and supports Windows, Linux, Android and Mac OS.
 * [VIGRA](https://github.com/ukoethe/vigra) - VIGRA is a generic cross-platform C++ computer vision and machine learning library for volumes of arbitrary dimensionality with Python bindings.
 
-<a name="cpp-general-purpose" />
+<a name="cpp-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [BanditLib](https://github.com/jkomiyama/banditlib) - A simple Multi-armed Bandit library.
@@ -181,7 +181,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Warp-CTC](https://github.com/baidu-research/warp-ctc) - A fast parallel implementation of Connectionist Temporal Classification (CTC), on both CPU and GPU.
 * [XGBoost](https://github.com/dmlc/xgboost) - A parallelized optimized general purpose gradient boosting library.
 
-<a name="cpp-nlp" />
+<a name="cpp-nlp"></a>
 #### Natural Language Processing
 
 * [BLLIP Parser](https://github.com/BLLIP/bllip-parser) - BLLIP Natural Language Parser (also known as the Charniak-Johnson parser)
@@ -197,34 +197,34 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 #### Speech Recognition
 * [Kaldi](https://github.com/kaldi-asr/kaldi) - Kaldi is a toolkit for speech recognition written in C++ and licensed under the Apache License v2.0. Kaldi is intended for use by speech recognition researchers.
 
-<a name="cpp-sequence" />
+<a name="cpp-sequence"></a>
 #### Sequence Analysis
 * [ToPS](https://github.com/ayoshiaki/tops) - This is an objected-oriented framework that facilitates the integration of probabilistic models for sequences over a user defined alphabet.
 
-<a name="cpp-gestures" />
+<a name="cpp-gestures"></a>
 #### Gesture Detection
 * [grt](https://github.com/nickgillian/grt) - The Gesture Recognition Toolkit (GRT) is a cross-platform, open-source, C++ machine learning library designed for real-time gesture recognition.
 
-<a name="common-lisp" />
+<a name="common-lisp"></a>
 ## Common Lisp
 
-<a name="common-lisp-general-purpose" />
+<a name="common-lisp-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [mgl](https://github.com/melisgl/mgl/) - Neural networks  (boltzmann machines, feed-forward and recurrent nets), Gaussian Processes
 * [mgl-gpr](https://github.com/melisgl/mgl-gpr/) - Evolutionary algorithms
 * [cl-libsvm](https://github.com/melisgl/cl-libsvm/) - Wrapper for the libsvm support vector machine library
 
-<a name="clojure" />
+<a name="clojure"></a>
 ## Clojure
 
-<a name="clojure-nlp" />
+<a name="clojure-nlp"></a>
 #### Natural Language Processing
 
 * [Clojure-openNLP](https://github.com/dakrone/clojure-opennlp) - Natural Language Processing in Clojure (opennlp)
 * [Infections-clj](https://github.com/r0man/inflections-clj) - Rails-like inflection library for Clojure and ClojureScript
 
-<a name="clojure-general-purpose" />
+<a name="clojure-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Touchstone](https://github.com/ptaoussanis/touchstone) - Clojure A/B testing library
@@ -240,38 +240,38 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [cortex](https://github.com/thinktopic/cortex) - Neural networks, regression and feature learning in Clojure.
 * [lambda-ml](https://github.com/cloudkj/lambda-ml) - Simple, concise implementations of machine learning techniques and utilities in Clojure.
 
-<a name="clojure-data-analysis" />
+<a name="clojure-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [Incanter](http://incanter.org/) - Incanter is a Clojure-based, R-like platform for statistical computing and graphics.
 * [PigPen](https://github.com/Netflix/PigPen) - Map-Reduce for Clojure.
 * [Envision](https://github.com/clojurewerkz/envision) - Clojure Data Visualisation library, based on Statistiker and D3
 
-<a name="elixir" />
+<a name="elixir"></a>
 ## Elixir
 
-<a name="elixir-general-purpose" />
+<a name="elixir-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Simple Bayes](https://github.com/fredwu/simple_bayes) - A Simple Bayes / Naive Bayes implementation in Elixir.
 
-<a name="elixir-nlp" />
+<a name="elixir-nlp"></a>
 #### Natural Language Processing
 
 * [Stemmer](https://github.com/fredwu/stemmer) - An English (Porter2) stemming implementation in Elixir.
 
-<a name="erlang" />
+<a name="erlang"></a>
 ## Erlang
 
-<a name="erlang-general-purpose" />
+<a name="erlang-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Disco](https://github.com/discoproject/disco/) - Map Reduce in Erlang
 
-<a name="go" />
+<a name="go"></a>
 ## Go
 
-<a name="go-nlp" />
+<a name="go-nlp"></a>
 #### Natural Language Processing
 
 * [go-porterstemmer](https://github.com/reiver/go-porterstemmer) - A native Go clean room implementation of the Porter Stemming algorithm.
@@ -279,7 +279,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [snowball](https://github.com/tebeka/snowball) - Snowball Stemmer for Go.
 * [go-ngram](https://github.com/Lazin/go-ngram) - In-memory n-gram index with compression.
 
-<a name="go-general-purpose" />
+<a name="go-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [gago](https://github.com/MaxHalford/gago) - Multi-population, flexible, parallel genetic algorithm.
@@ -294,7 +294,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [MXNet](https://github.com/dmlc/mxnet) - Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler; for Python, R, Julia, Go, Javascript and more.
 * [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) - Go binding for MXNet c_predict_api to do inference with pre-trained model
 
-<a name="go-data-analysis" />
+<a name="go-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [go-graph](https://github.com/StepLg/go-graph) - Graph library for Go/golang language.
@@ -302,10 +302,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [RF](https://github.com/fxsjy/RF.go) - Random forests implementation in Go
 
 
-<a name="haskell" />
+<a name="haskell"></a>
 ## Haskell
 
-<a name="haskell-general-purpose" />
+<a name="haskell-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [haskell-ml](https://github.com/ajtulloch/haskell-ml) - Haskell implementations of various ML algorithms.
 * [HLearn](https://github.com/mikeizbicki/HLearn) - a suite of libraries for interpreting machine learning models according to their algebraic structure.
@@ -314,10 +314,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [caffegraph](https://github.com/ajtulloch/dnngraph) - A DSL for deep neural networks
 * [LambdaNet](https://github.com/jbarrow/LambdaNet) - Configurable Neural Networks in Haskell
 
-<a name="java" />
+<a name="java"></a>
 ## Java
 
-<a name="java-nlp" />
+<a name="java-nlp"></a>
 #### Natural Language Processing
 * [Cortical.io](http://www.cortical.io/) - Retina: an API performing complex NLP operations (disambiguation, classification, streaming text filtering, etc...) as quickly and intuitively as the brain.
 * [CoreNLP](http://nlp.stanford.edu/software/corenlp.shtml) - Stanford CoreNLP provides a set of natural language analysis tools which can take raw English language text input and give the base forms of words
@@ -341,7 +341,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [ClearNLP](https://github.com/clir/clearnlp) - The ClearNLP project provides software and resources for natural language processing. The project started at the Center for Computational Language and EducAtion Research, and is currently developed by the Center for Language and Information Research at Emory University. This project is under the Apache 2 license.
 * [CogcompNLP](https://github.com/IllinoisCogComp/illinois-cogcomp-nlp) - This project collects a number of core libraries for Natural Language Processing (NLP) developed in the University of Illinois' Cognitive Computation Group, for example `illinois-core-utilities` which provides a set of NLP-friendly data structures and a number of NLP-related utilities that support writing NLP applications, running experiments, etc, `illinois-edison` a library for feature extraction from illinois-core-utilities data structures and many other packages.
 
-<a name="java-general-purpose" />
+<a name="java-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [aerosolve](https://github.com/airbnb/aerosolve) - A machine learning library by Airbnb designed from the ground up to be human friendly.
@@ -373,7 +373,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 #### Speech Recognition
 * [CMU Sphinx](http://cmusphinx.sourceforge.net/) - Open Source Toolkit For Speech Recognition purely based on Java speech recognition library.
 
-<a name="java-data-analysis" />
+<a name="java-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [Flink](http://flink.apache.org/) - Open source platform for distributed stream and batch data processing.
@@ -384,15 +384,15 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [DataMelt](http://jwork.org/dmelt/) - Mathematics software for numeric computation, statistics, symbolic calculations, data analysis and data visualization.
 * [Dr. Michael Thomas Flanagan's Java Scientific Library](http://www.ee.ucl.ac.uk/~mflanaga/java/)
 
-<a name="java-deep-learning" />
+<a name="java-deep-learning"></a>
 #### Deep Learning
 
 * [Deeplearning4j](https://github.com/deeplearning4j/deeplearning4j) - Scalable deep learning for industry with parallel GPUs
 
-<a name="javascript" />
+<a name="javascript"></a>
 ## Javascript
 
-<a name="javascript-nlp" />
+<a name="javascript-nlp"></a>
 #### Natural Language Processing
 
 * [Twitter-text](https://github.com/twitter/twitter-text) - A JavaScript implementation of Twitter's text processing library
@@ -404,7 +404,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [NLP Compromise](https://github.com/nlp-compromise/compromise) - Natural Language processing in the browser
 
 
-<a name="javascript-data-analysis" />
+<a name="javascript-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [D3.js](https://d3js.org/)
@@ -426,7 +426,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [cheminfo](http://www.cheminfo.org/) - Platform for data visualization and analysis, using the [visualizer](https://github.com/npellet/visualizer) project.
 
 
-<a name="javascript-general-purpose" />
+<a name="javascript-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Convnet.js](http://cs.stanford.edu/people/karpathy/convnetjs/) - ConvNetJS is a Javascript library for training Deep Learning models[DEEP LEARNING]
@@ -454,7 +454,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Pavlov.js](https://github.com/NathanEpstein/Pavlov.js) - Reinforcement learning using Markov Decision Processes
 * [MXNet](https://github.com/dmlc/mxnet) - Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler; for Python, R, Julia, Go, Javascript and more.
 
-<a name="javascript-misc" />
+<a name="javascript-misc"></a>
 #### Misc
 
 * [sylvester](https://github.com/jcoglan/sylvester) - Vector and Matrix math for JavaScript.
@@ -463,10 +463,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Lyric](https://github.com/flurry/Lyric) - Linear Regression library.
 * [GreatCircle](https://github.com/mwgg/GreatCircle) - Library for calculating great circle distance.
 
-<a name="julia" />
+<a name="julia"></a>
 ## Julia
 
-<a name="julia-general-purpose" />
+<a name="julia-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [MachineLearning](https://github.com/benhamner/MachineLearning.jl) - Julia Machine Learning library
@@ -502,14 +502,14 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl) - Julia implementation of the scikit-learn API
 * [Knet](https://github.com/denizyuret/Knet.jl) - Koç University Deep Learning Framework
 
-<a name="julia-nlp" />
+<a name="julia-nlp"></a>
 #### Natural Language Processing
 
 * [Topic Models](https://github.com/slycoder/TopicModels.jl) - TopicModels for Julia
 * [Text Analysis](https://github.com/johnmyleswhite/TextAnalysis.jl) - Julia package for text analysis
 
 
-<a name="julia-data-analysis" />
+<a name="julia-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [Graph Layout](https://github.com/IainNZ/GraphLayout.jl) - Graph layout algorithms in pure Julia
@@ -527,7 +527,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Time Series](https://github.com/JuliaStats/TimeSeries.jl) - Time series toolkit for Julia
 * [Sampling](https://github.com/lindahua/Sampling.jl) - Basic sampling algorithms for Julia
 
-<a name="julia-misc" />
+<a name="julia-misc"></a>
 #### Misc Stuff / Presentations
 
 * [DSP](https://github.com/JuliaDSP/DSP.jl) - Digital Signal Processing (filtering, periodograms, spectrograms, window functions).
@@ -535,10 +535,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [SignalProcessing](https://github.com/davidavdav/SignalProcessing.jl) - Signal Processing tools for Julia
 * [Images](https://github.com/JuliaImages/Images.jl) - An image library for Julia
 
-<a name="lua" />
+<a name="lua"></a>
 ## Lua
 
-<a name="lua-general-purpose" />
+<a name="lua-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Torch7](http://torch.ch/)
@@ -579,7 +579,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Lua - Numerical Algorithms](https://bitbucket.org/lucashnegri/lna)
 * [Lunum](https://github.com/jzrake/lunum)
 
-<a name="lua-demos" />
+<a name="lua-demos"></a>
 #### Demos and Scripts
 * [Core torch7 demos repository](https://github.com/e-lab/torch7-demos).
   * linear-regression, logistic-regression
@@ -607,10 +607,10 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 
 
 
-<a name="matlab" />
+<a name="matlab"></a>
 ## Matlab
 
-<a name="matlab-cv" />
+<a name="matlab-cv"></a>
 #### Computer Vision
 
 * [Contourlets](http://www.ifp.illinois.edu/~minhdo/software/contourlet_toolbox.tar) - MATLAB source code that implements the contourlet transform and its utility functions.
@@ -619,12 +619,12 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [Bandlets](http://www.cmap.polytechnique.fr/~peyre/download/) - MATLAB code for bandlet transform
 * [mexopencv](http://kyamagu.github.io/mexopencv/) - Collection and a development kit of MATLAB mex functions for OpenCV library
 
-<a name="matlab-nlp" />
+<a name="matlab-nlp"></a>
 #### Natural Language Processing
 
 * [NLP](https://amplab.cs.berkeley.edu/an-nlp-library-for-matlab/) - An NLP library for Matlab
 
-<a name="matlab-general-purpose" />
+<a name="matlab-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Training a deep autoencoder or a classifier
@@ -641,16 +641,16 @@ on MNIST digits[DEEP LEARNING]
 * [Pattern Recognition and Machine Learning](https://github.com/PRML/PRMLT) - This package contains the matlab implementation of the algorithms described in the book Pattern Recognition and Machine Learning by C. Bishop.
 * [Optunity](http://optunity.readthedocs.io/en/latest/) - A library dedicated to automated hyperparameter optimization with a simple, lightweight API to facilitate drop-in replacement of grid search. Optunity is written in Python but interfaces seamlessly with MATLAB.
 
-<a name="matlab-data-analysis" />
+<a name="matlab-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [matlab_gbl](https://www.cs.purdue.edu/homes/dgleich/packages/matlab_bgl/) - MatlabBGL is a Matlab package for working with graphs.
 * [gamic](http://www.mathworks.com/matlabcentral/fileexchange/24134-gaimc---graph-algorithms-in-matlab-code) - Efficient pure-Matlab implementations of graph algorithms to complement MatlabBGL's mex functions.
 
-<a name="net" />
+<a name="net"></a>
 ## .NET
 
-<a name="net-cv" />
+<a name="net-cv"></a>
 #### Computer Vision
 
 * [OpenCVDotNet](https://code.google.com/archive/p/opencvdotnet) - A wrapper for the OpenCV project to be used with .NET applications.
@@ -658,12 +658,12 @@ on MNIST digits[DEEP LEARNING]
 * [AForge.NET](http://www.aforgenet.com/framework/) - Open source C# framework for developers and researchers in the fields of Computer Vision and Artificial Intelligence. Development has now shifted to GitHub.
 * [Accord.NET](http://accord-framework.net) - Together with AForge.NET, this library can provide image processing and computer vision algorithms to Windows, Windows RT and Windows Phone. Some components are also available for Java and Android.
 
-<a name="net-nlp" />
+<a name="net-nlp"></a>
 #### Natural Language Processing
 
 * [Stanford.NLP for .NET](https://github.com/sergey-tihon/Stanford.NLP.NET/) - A full port of Stanford NLP packages to .NET and also available precompiled as a NuGet package.
 
-<a name="net-general-purpose" />
+<a name="net-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Accord-Framework](http://accord-framework.net/) -The Accord.NET Framework is a complete framework for building machine learning, computer vision, computer audition, signal processing and statistical applications.
@@ -673,7 +673,7 @@ on MNIST digits[DEEP LEARNING]
 * [Encog](http://www.nuget.org/packages/encog-dotnet-core/) -  An advanced neural network and machine learning framework. Encog contains classes to create a wide variety of networks, as well as support classes to normalize and process data for these neural networks. Encog trains using multithreaded resilient propagation. Encog can also make use of a GPU to further speed processing time. A GUI based workbench is also provided to help model and train neural networks.
 * [Neural Network Designer](http://bragisoft.com/) - DBMS management system and designer for neural networks. The designer application is developed using WPF, and is a user interface which allows you to design your neural network, query the network, create and configure chat bots that are capable of asking questions and learning from your feed back.  The chat bots can even scrape the internet for information to return in their output as well as to use for learning.
 
-<a name="net-data-analysis" />
+<a name="net-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [numl](http://www.nuget.org/packages/numl/) - numl is a machine learning library intended to ease the use of using standard modeling techniques for both prediction and clustering.
@@ -718,10 +718,10 @@ on MNIST digits[DEEP LEARNING]
 * [PHP-ML](https://github.com/php-ai/php-ml) - Machine Learning library for PHP. Algorithms, Cross Validation, Neural Network, Preprocessing, Feature Extraction and much more in one library.
 * [PredictionBuilder](https://github.com/denissimon/prediction-builder) - A library for machine learning that builds predictions using a linear regression.
 
-<a name="python" />
+<a name="python"></a>
 ## Python
 
-<a name="python-cv" />
+<a name="python-cv"></a>
 #### Computer Vision
 
 * [Scikit-Image](https://github.com/scikit-image/scikit-image) - A collection of algorithms for image processing in Python.
@@ -730,7 +730,7 @@ on MNIST digits[DEEP LEARNING]
 * [OpenFace](https://cmusatyalab.github.io/openface/) - Free and open source face recognition with deep neural networks.
 * [PCV](https://github.com/jesolem/PCV) - Open source Python module for computer vision
 
-<a name="python-nlp" />
+<a name="python-nlp"></a>
 #### Natural Language Processing
 
 * [NLTK](http://www.nltk.org/) - A leading platform for building Python programs to work with human language data.
@@ -761,7 +761,7 @@ on MNIST digits[DEEP LEARNING]
 * [textacy](https://github.com/chartbeat-labs/textacy) - higher-level NLP built on Spacy
 * [stanford-corenlp-python](https://github.com/dasmith/stanford-corenlp-python) - Python wrapper for [Stanford CoreNLP](https://github.com/stanfordnlp/CoreNLP)
 
-<a name="python-general-purpose" />
+<a name="python-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [auto_ml](https://github.com/ClimbsRocks/auto_ml) - Automated machine learning for production and analytics. Lets you focus on the fun parts of ML, while outputting production-ready code, and detailed analytics of your dataset and results. Includes support for NLP, XGBoost, LightGBM, and soon, deep learning. 
 * [machine learning](https://github.com/jeff1evesque/machine-learning) - automated build consisting of a [web-interface](https://github.com/jeff1evesque/machine-learning#web-interface), and set of [programmatic-interface](https://github.com/jeff1evesque/machine-learning#programmatic-interface) API, for support vector machines.  Corresponding dataset(s) are stored into a SQL database, then generated model(s) used for prediction(s), are stored into a NoSQL datastore.
@@ -831,7 +831,7 @@ on MNIST digits[DEEP LEARNING]
 * [skbayes](https://github.com/AmazaspShumik/sklearn-bayes) - Python package for Bayesian Machine Learning with scikit-learn API
 * [fuku-ml](https://github.com/fukuball/fuku-ml) - Simple machine learning library, including Perceptron, Regression, Support Vector Machine, Decision Tree and more, it's easy to use and easy to learn for beginners.
 
-<a name="python-data-analysis" />
+<a name="python-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [SciPy](http://www.scipy.org/) - A Python-based ecosystem of open-source software for mathematics, science, and engineering.
@@ -879,7 +879,7 @@ on MNIST digits[DEEP LEARNING]
 * [visualize_ML](https://github.com/ayush1997/visualize_ML) - A python package for data exploration and data analysis.
 * [scikit-plot](https://github.com/reiinakano/scikit-plot) - A visualization library for quick and easy generation of common plots in data analysis and machine learning.
 
-<a name="python-misc" />
+<a name="python-misc"></a>
 #### Misc Scripts / iPython Notebooks / Codebases
 * [BioPy](https://github.com/jaredthecoder/BioPy) - Biologically-Inspired and Machine Learning Algorithms in Python.
 * [pattern_classification](https://github.com/rasbt/pattern_classification)
@@ -924,7 +924,7 @@ on MNIST digits[DEEP LEARNING]
 * [Neuron](https://github.com/molcik/python-neuron) - Neuron is simple class for time series predictions. It's utilize LNU (Linear Neural Unit), QNU (Quadratic Neural Unit), RBF (Radial Basis Function), MLP (Multi Layer Perceptron), MLP-ELM (Multi Layer Perceptron - Extreme Learning Machine) neural networks learned with Gradient descent or LeLevenberg–Marquardt algorithm.
 * [Data Driven Code](https://github.com/atmb4u/data-driven-code) - Very simple implementation of neural networks for dummies in python without using any libraries, with detailed comments.
 
-<a name="python-kaggle" />
+<a name="python-kaggle"></a>
 #### Kaggle Competition Source Code
 
 
@@ -947,10 +947,10 @@ on MNIST digits[DEEP LEARNING]
 * [kaggle_acquire-valued-shoppers-challenge](https://github.com/MLWave/kaggle_acquire-valued-shoppers-challenge) - Code for the Kaggle acquire valued shoppers challenge
 * [wine-quality](https://github.com/zygmuntz/wine-quality) - Predicting wine quality
 
-<a name="ruby" />
+<a name="ruby"></a>
 ## Ruby
 
-<a name="ruby-nlp" />
+<a name="ruby-nlp"></a>
 #### Natural Language Processing
 
 * [Treat](https://github.com/louismullie/treat) -  Text REtrieval and Annotation Toolkit, definitely the most comprehensive toolkit I’ve encountered so far for Ruby
@@ -961,7 +961,7 @@ on MNIST digits[DEEP LEARNING]
 * [UEA Stemmer](https://github.com/ealdent/uea-stemmer) - Ruby port of UEALite Stemmer - a conservative stemmer for search and indexing
 * [Twitter-text-rb](https://github.com/twitter/twitter-text-rb) - A library that does auto linking and extraction of usernames, lists and hashtags in tweets
 
-<a name="ruby-general-purpose" />
+<a name="ruby-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Ruby Machine Learning](https://github.com/tsycho/ruby-machine-learning) - Some Machine Learning algorithms, implemented in Ruby
@@ -971,7 +971,7 @@ on MNIST digits[DEEP LEARNING]
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM which is a Library for Support Vector Machines
 * [Random Forester](https://github.com/asafschers/random_forester) - Creates Random Forest classifiers from PMML files
 
-<a name="ruby-data-analysis" />
+<a name="ruby-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [rsruby](https://github.com/alexgutteridge/rsruby) - Ruby - R bridge
@@ -984,17 +984,17 @@ on MNIST digits[DEEP LEARNING]
 * [Bioruby](https://github.com/bioruby/bioruby)
 * [Arel](https://github.com/nkallen/arel)
 
-<a name="ruby-misc" />
+<a name="ruby-misc"></a>
 #### Misc
 
 * [Big Data For Chimps](https://github.com/infochimps-labs/big_data_for_chimps)
 * [Listof](https://github.com/kevincobain2000/listof) - Community based data collection, packed in gem. Get list of pretty much anything (stop words, countries, non words) in txt, json or hash. [Demo/Search for a list](http://kevincobain2000.github.io/listof/)
 
 
-<a name="rust" />
+<a name="rust"></a>
 ## Rust
 
-<a name="rust-general-purpose" />
+<a name="rust-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [deeplearn-rs](https://github.com/tedsta/deeplearn-rs) - deeplearn-rs provides simple networks that use matrix multiplication, addition, and ReLU under the MIT license.
 * [rustlearn](https://github.com/maciejkula/rustlearn) - a machine learning framework featuring logistic regression, support vector machines, decision trees and random forests.
@@ -1003,10 +1003,10 @@ on MNIST digits[DEEP LEARNING]
 * [RustNN](https://github.com/jackm321/RustNN) - RustNN is a feedforward neural network library.
 
 
-<a name="r" />
+<a name="r"></a>
 ## R
 
-<a name="r-general-purpose" />
+<a name="r-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [ahaz](http://cran.r-project.org/web/packages/ahaz/index.html) - ahaz: Regularization for semiparametric additive hazards regression
@@ -1098,40 +1098,40 @@ on MNIST digits[DEEP LEARNING]
 * [MXNet](https://github.com/dmlc/mxnet) - Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler; for Python, R, Julia, Go, Javascript and more.
 * [TDSP-Utilities](https://github.com/Azure/Azure-TDSP-Utilities) - Two data science utilities in R from Microsoft: 1) Interactive Data Exploration, Analysis, and Reporting (IDEAR) ; 2) Automated Modeling and Reporting (AMR).
 
-<a name="r-data-analysis" />
+<a name="r-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [ggplot2](http://ggplot2.org/) - A data visualization package based on the grammar of graphics.
 
-<a name="sas" />
+<a name="sas"></a>
 ## SAS
 
-<a name="sas-general-purpose" />
+<a name="sas-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Enterprise Miner](https://www.sas.com/en_us/software/enterprise-miner.html) - Data mining and machine learning that creates deployable models using a GUI or code.
 * [Factory Miner](https://www.sas.com/en_us/software/factory-miner.html) - Automatically creates deployable machine learning models across numerous market or customer segments using a GUI.
 
-<a name="sas-data-analysis" />
+<a name="sas-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [SAS/STAT](https://www.sas.com/en_us/software/analytics/stat.html) - For conducting advanced statistical analysis.
 * [University Edition](https://www.sas.com/en_us/software/university-edition.html) - FREE! Includes all SAS packages necessary for data analysis and visualization, and includes online SAS courses.
 
-<a name="sas-mpp" />
+<a name="sas-mpp"></a>
 #### High Performance Machine Learning
 
 * [High Performance Data Mining](https://www.sas.com/en_us/software/analytics/high-performance-data-mining.html) - Data mining and machine learning that creates deployable models using a GUI or code in an MPP environment, including Hadoop.
 * [High Performance Text Mining](https://www.sas.com/en_us/software/analytics/high-performance-text-mining.html) - Text mining using a GUI or code in an MPP environment, including Hadoop.
 
-<a name="sas-nlp" />
+<a name="sas-nlp"></a>
 #### Natural Language Processing
 
 * [Contextual Analysis](https://www.sas.com/en_us/software/analytics/contextual-analysis.html) - Add structure to unstructured text using a GUI.
 * [Sentiment Analysis](https://www.sas.com/en_us/software/analytics/sentiment-analysis.html) - Extract sentiment from text using a GUI.
 * [Text Miner](https://www.sas.com/en_us/software/analytics/text-miner.html) - Text mining using a GUI or code.
 
-<a name="sas-demos" />
+<a name="sas-demos"></a>
 #### Demos and Scripts
 
 * [ML_Tables](https://github.com/sassoftware/enlighten-apply/tree/master/ML_tables) - Concise cheat sheets containing machine learning best practices.
@@ -1141,10 +1141,10 @@ on MNIST digits[DEEP LEARNING]
 * [dm-flow](https://github.com/sassoftware/dm-flow) - Library of SAS Enterprise Miner process flow diagrams to help you learn by example about specific data mining topics.
 
 
-<a name="scala" />
+<a name="scala"></a>
 ## Scala
 
-<a name="scala-nlp" />
+<a name="scala-nlp"></a>
 #### Natural Language Processing
 
 * [ScalaNLP](http://www.scalanlp.org/) - ScalaNLP is a suite of machine learning and numerical computing libraries.
@@ -1152,7 +1152,7 @@ on MNIST digits[DEEP LEARNING]
 * [Chalk](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library.
 * [FACTORIE](https://github.com/factorie/factorie) - FACTORIE is a toolkit for deployable probabilistic modeling, implemented as a software library in Scala. It provides its users with a succinct language for creating relational factor graphs, estimating parameters and performing inference.
 
-<a name="scala-data-analysis" />
+<a name="scala-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
 * [MLlib in Apache Spark](http://spark.apache.org/docs/latest/mllib-guide.html) - Distributed machine learning library in Spark
@@ -1168,7 +1168,7 @@ on MNIST digits[DEEP LEARNING]
 * [Flink](http://flink.apache.org/) - Open source platform for distributed stream and batch data processing.
 * [Spark Notebook](http://spark-notebook.io) - Interactive and Reactive Data Science using Scala and Spark.
 
-<a name="scala-general-purpose" />
+<a name="scala-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Conjecture](https://github.com/etsy/Conjecture) - Scalable Machine Learning in Scalding
@@ -1184,10 +1184,10 @@ on MNIST digits[DEEP LEARNING]
 * [Saul](https://github.com/IllinoisCogComp/saul/) - Flexible Declarative Learning-Based Programming.
 * [SwiftLearner](https://github.com/valdanylchuk/swiftlearner/) - Simply written algorithms to help study ML or write your own implementations.
 
-<a name="swift" />
+<a name="swift"></a>
 ## Swift
 
-<a name="swift-general-purpose" />
+<a name="swift-general-purpose"></a>
 #### General-Purpose Machine Learning
 
 * [Swift AI](https://github.com/collinhundley/Swift-AI) - Highly optimized artificial intelligence and machine learning library written in Swift.
@@ -1200,14 +1200,14 @@ on MNIST digits[DEEP LEARNING]
 * [MLKit](https://github.com/Somnibyte/MLKit) - A simple Machine Learning Framework written in Swift. Currently features Simple Linear Regression, Polynomial Regression, and Ridge Regression.
 * [Swift Brain](https://github.com/vlall/Swift-Brain) - The first neural network / machine learning library written in Swift. This is a project for AI algorithms in Swift for iOS and OS X development. This project includes algorithms focused on Bayes theorem, neural networks, SVMs, Matrices, etc..
 
-<a name="tensor" />
+<a name="tensor"></a>
 ## TensorFlow
 
-<a name="tensor-general-purpose" />
+<a name="tensor-general-purpose"></a>
 #### General-Purpose Machine Learning
 * [Awesome TensorFlow](https://github.com/jtoy/awesome-tensorflow) - A list of all things related to TensorFlow
 
-<a name="credits" />
+<a name="credits"></a>
 ## Credits
 
 * Some of the python libraries were cut-and-pasted from [vinta](https://github.com/vinta/awesome-python)

--- a/meetups.md
+++ b/meetups.md
@@ -3,9 +3,9 @@ The following is a list of free-to-attend meetups and local events on Machine Le
 - [India](#india)
     -   [Bangalore](#bangalore)
 
-<a name="india" />
+<a name="india"></a>
 ## India
 
-<a name="bangalore" />
+<a name="bangalore"></a>
 ### Bangalore
 * [Bangalore Machine Learning Meetup (BangML)](https://www.meetup.com/BangML/)


### PR DESCRIPTION
HTML5 `a` elements are non-void so do not support self-closing tag syntax. This was causing Github to process
```
<a id="title" />
## Title
```

as

```
<a id="title">## Title</a>
```
 and not apply the expected formatting.
