### PR TITLE
Add word embedding in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ For a list of free-to-attend meetups and local events, go [here](https://github.
 * [paicehusk](https://github.com/Rookii/paicehusk) - Golang implementation of the Paice/Husk Stemming Algorithm.
 * [snowball](https://github.com/tebeka/snowball) - Snowball Stemmer for Go.
 * [go-ngram](https://github.com/Lazin/go-ngram) - In-memory n-gram index with compression.
+* [word-embedding](github.com/ynqa/word-embedding) - Word Embeddings: the full implementation of word2vec, GloVe in Go.
 
 <a name="go-general-purpose"></a>
 #### General-Purpose Machine Learning


### PR DESCRIPTION
This repo is the models to embed words to vector space, so-called word embedding, or word representation.
These models are written in Golang from scratch :)
So, you're able to build word vector and estimate similarity list between words with CLI, please see usage!
Now it's supported word2vec only, but will be dealt with GloVe, SPPMI from on now.