### PR TITLE
Add stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Further resources:
 <a name="javascript-misc"></a>
 #### Misc
 
+* [stdlib](https://github.com/stdlib-js/stdlib) - A standard library for JavaScript and Node.js, with an emphasis on numeric computing. The library provides a collection of robust, high performance libraries for mathematics, statistics, streams, utilities, and more.
 * [sylvester](https://github.com/jcoglan/sylvester) - Vector and Matrix math for JavaScript.
 * [simple-statistics](https://github.com/simple-statistics/simple-statistics) - A JavaScript implementation of descriptive, regression, and inference statistics. Implemented in literate JavaScript with no dependencies, designed to work in all modern browsers (including IE) as well as in Node.js.
 * [regression-js](https://github.com/Tom-Alexander/regression-js) - A javascript library containing a collection of least squares fitting methods for finding a trend in a set of data.


### PR DESCRIPTION
This PR adds [stdlib](https://github.com/stdlib-js/stdlib) to the list of JavaScript resources. The library contains over 1500+ packages, includes BLAS native bindings, and has compiled WebAssembly modules.