### PR TITLE
Add Cogitare

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,7 @@ be
 * [CatBoost](https://github.com/catboost/catboost) - Gradient boosting on decision trees library with categorical features support out of the box for Python, R.
 * [stacked_generalization](https://github.com/fukatani/stacked_generalization) - Implementation of machine learning stacking technic as handy library in Python.
 * [modAL](https://cosmic-cortex.github.io/modAL) - A modular active learning framework for Python, built on top of scikit-learn.
+* [Cogitare](https://github.com/cogitare-ai/cogitare): A Modern, Fast, and Modular Deep Learning and Machine Learning framework for Python. 
 
 <a name="python-data-analysis"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Add Cogitare, a deep learning framework built on top of PyTorch.

Docs: http://docs.cogitare-ai.org/
Tutorials: http://tutorials.cogitare-ai.org/