### PR TITLE
Update the link for Applied Numerical Computing

### DIFF
--- a/books.md
+++ b/books.md
@@ -85,5 +85,5 @@ The following is a list of free, open source books on machine learning, statisti
 * [Linear Algebra Done Wrong](http://www.math.brown.edu/~treil/papers/LADW/LADW.html)
 * [Linear Algebra, Theory, and Applications](https://math.byu.edu/~klkuttle/Linearalgebra.pdf)
 * [Convex Optimization](http://web.stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf)
-* [Applied Numerical Computing](http://www.seas.ucla.edu/~vandenbe/103/reader.pdf)
+* [Applied Numerical Computing](http://www.seas.ucla.edu/~vandenbe/ee133a.html)
 * [Applied Numerical Linear Algebra](http://egrcc.github.io/docs/math/applied-numerical-linear-algebra.pdf)


### PR DESCRIPTION
Fix the broken link of the book Applied
Numerical Computing.