### PR TITLE
Add link to machine learning algorithms implemented for MatLab/Octave.

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ on MNIST digits[DEEP LEARNING].
 * [Pattern Recognition and Machine Learning](https://github.com/PRML/PRMLT) - This package contains the matlab implementation of the algorithms described in the book Pattern Recognition and Machine Learning by C. Bishop.
 * [Optunity](http://optunity.readthedocs.io/en/latest/) - A library dedicated to automated hyperparameter optimization with a simple, lightweight API to facilitate drop-in replacement of grid search. Optunity is written in Python but interfaces seamlessly with MATLAB.
 * [MXNet](https://github.com/apache/incubator-mxnet/) - Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler; for Python, R, Julia, Go, Javascript and more.
+* [Machine Learning in MatLab/Octave](https://github.com/trekhleb/machine-learning-octave) - examples of popular machine learning algorithms (neural networks, linear/logistic regressions, K-Means, etc.) with code examples and mathematics behind them being explained.
 
 
 <a name="matlab-data-analysis"></a>


### PR DESCRIPTION
The link is for the new GitHub repository that contains MatLab/Octave examples of popular machine learning algorithms with code examples and mathematics being explained.