### PR TITLE
Add MindsDB 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ be
 * [mlens](https://github.com/flennerhag/mlens) - A high performance, memory efficient, maximally parallelized ensemble learning, integrated with scikit-learn.
 * [Netron](https://github.com/lutzroeder/netron) - Visualizer for machine learning models.
 * [Thampi](https://github.com/scoremedia/thampi) - Machine Learning Prediction System on AWS Lambda
+* [MindsDB](https://github.com/mindsdb/mindsdb) - Open Source framework to streamline use of neural networks.
 
 <a name="python-data-analysis"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
This PR adds MindsDB to the Python General Machine Learning section. MindsDB is open source project which goal is to make it very simple for developers to use the power of artificial neural networks in their projects.

