### PR TITLE
Added Spark NLP to Scala NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,7 @@ be
 * [Chalk](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library. **[Deprecated]**
 * [FACTORIE](https://github.com/factorie/factorie) - FACTORIE is a toolkit for deployable probabilistic modeling, implemented as a software library in Scala. It provides its users with a succinct language for creating relational factor graphs, estimating parameters and performing inference.
 * [Montague](https://github.com/Workday/upshot-montague) - Montague is a semantic parsing library for Scala with an easy-to-use DSL.
+* [Spark NLP](https://github.com/JohnSnowLabs/spark-nlp) - Natural language processing library built on top of Apache Spark ML to provide simple, performant, and accurate NLP annotations for machine learning pipelines, that scale easily in a distributed environment.
 
 <a name="scala-data-analysis"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Spark NLP natively supports Apache Spark and sits on top of the Spark ML Pipeline. It comes with pre-trained models and the ability to train your own models by using machine learning and deep learning algorithms.
Spark NLP fully supports both Java/Scala and Python APIs.