### PR TITLE
Add bentoML for python general purpose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ be
 * [Gorgonia](https://github.com/gorgonia/gorgonia) - Gorgonia is a library that helps facilitate machine learning in Golang.
 * [Microsoft Recommenders](https://github.com/Microsoft/Recommenders): Examples and best practices for building recommendation systems, provided as Jupyter notebooks. The repo contains some of the latest state of the art algorithms from Microsoft Research as well as from other companies and institutions.
 * [StellarGraph](https://github.com/stellargraph/stellargraph): Machine Learning on Graphs, a Python library for machine learning on graph-structured (network-structured) data.
+* [BentoML](https://github.com/bentoml/bentoml): Toolkit for package and deploy machine learning models for serving in production
 
 <a name="python-data-analysis"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Hi @josephmisiti 

Thank you for putting together this awesome list.  I would like to add BentoML for Python's general purpose ML section.  It is a toolkit that package and deploy model to production.



