### PR TITLE
update the Go section

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,6 @@ Further resources:
 #### Natural Language Processing
 
 * [snowball](https://github.com/tebeka/snowball) - Snowball Stemmer for Go.
-* [Textbox](https://godoc.org/github.com/machinebox/sdk-go/textbox) - Natural language processing SDK from Machine Box
 * [word-embedding](https://github.com/ynqa/word-embedding) - Word Embeddings: the full implementation of word2vec, GloVe in Go.
 * [sentences](https://github.com/neurosnap/sentences) - Golang implementation of Punkt sentence tokenizer.
 * [go-ngram](https://github.com/Lazin/go-ngram) - In-memory n-gram index with compression. *[Deprecated]*
@@ -377,10 +376,7 @@ Further resources:
 <a name="go-computer-vision"></a>
 #### Computer vision 
 
-* [Facebox](https://godoc.org/github.com/machinebox/sdk-go/facebox) - Facial detection and recognition SDK with one-shot teaching from Machine Box
 * [GoCV](https://github.com/hybridgroup/gocv) - Package for computer vision using OpenCV 4 and beyond. 
-* [Nudebox](https://godoc.org/github.com/machinebox/sdk-go/nudebox) - Nudity detection from Machine Box
-* [Tagbox](https://godoc.org/github.com/machinebox/sdk-go/tagbox) - Image classification SDK with one-shot teaching from Machine Box
 
 <a name="haskell"></a>
 ## Haskell

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Further resources:
     - [Natural Language Processing](#go-nlp)
     - [General-Purpose Machine Learning](#go-general-purpose)
     - [Data Analysis / Data Visualization](#go-data-analysis)
-    - [Facial Detection and Recognition](#go-facial-recognition)
-    - [Image Classification](#go-image-classification)
+    - [Geometry / Spatial Analysis](#go-spatial-analysis)
+    - [Computer Vision](#go-computer-vision)
 - [Haskell](#haskell)
     - [General-Purpose Machine Learning](#haskell-general-purpose)
 - [Java](#java)
@@ -324,49 +324,63 @@ Further resources:
 <a name="go-nlp"></a>
 #### Natural Language Processing
 
-* [go-porterstemmer](https://github.com/reiver/go-porterstemmer) - A native Go clean room implementation of the Porter Stemming algorithm. **[Deprecated]**
-* [paicehusk](https://github.com/Rookii/paicehusk) - Golang implementation of the Paice/Husk Stemming Algorithm.
 * [snowball](https://github.com/tebeka/snowball) - Snowball Stemmer for Go.
 * [Textbox](https://godoc.org/github.com/machinebox/sdk-go/textbox) - Natural language processing SDK from Machine Box
-* [go-ngram](https://github.com/Lazin/go-ngram) - In-memory n-gram index with compression.
 * [word-embedding](https://github.com/ynqa/word-embedding) - Word Embeddings: the full implementation of word2vec, GloVe in Go.
 * [sentences](https://github.com/neurosnap/sentences) - Golang implementation of Punkt sentence tokenizer.
+* [go-ngram](https://github.com/Lazin/go-ngram) - In-memory n-gram index with compression. *[Deprecated]*
+* [paicehusk](https://github.com/Rookii/paicehusk) - Golang implementation of the Paice/Husk Stemming Algorithm. *[Deprecated]*
+* [go-porterstemmer](https://github.com/reiver/go-porterstemmer) - A native Go clean room implementation of the Porter Stemming algorithm. **[Deprecated]**
 
 <a name="go-general-purpose"></a>
 #### General-Purpose Machine Learning
 
+* [birdland](https://github.com/rlouf/birdland) - A recommendation library in Go.
 * [eaopt](https://github.com/MaxHalford/eaopt) - An evolutionary optimization library.
-* [Go Learn](https://github.com/sjwhitworth/golearn) - Machine Learning for Go. **[Deprecated]**
+* [leaves](https://github.com/dmitryikh/leaves) - A pure Go implementation of the prediction part of GBRTs, including XGBoost and LightGBM.
+* [gobrain](https://github.com/goml/gobrain) - Neural Networks written in Go.
+* [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) - Go binding for MXNet c_predict_api to do inference with pre-trained model.
+* [go-ml-transpiler](https://github.com/znly/go-ml-transpiler) - An open source Go transpiler for machine learning models.
+* [golearn](https://github.com/sjwhitworth/golearn) - Machine learning for Go.
+* [goml](https://github.com/cdipaolo/goml) - Machine learning library written in pure Go.
+* [gorgonia](https://github.com/gorgonia/gorgonia) - Deep learning in Go.
+* [therfoo](https://github.com/therfoo/therfoo) - An embedded deep learning library for Go.
+* [neat](https://github.com/jinyeom/neat) - Plug-and-play, parallel Go framework for NeuroEvolution of Augmenting Topologies (NEAT). **[Deprecated]**
 * [go-pr](https://github.com/daviddengcn/go-pr) - Pattern recognition package in Go lang. **[Deprecated]**
 * [go-ml](https://github.com/alonsovidales/go_ml) - Linear / Logistic regression, Neural Networks, Collaborative Filtering and Gaussian Multivariate Distribution. **[Deprecated]**
+* [GoNN](https://github.com/fxsjy/gonn) - GoNN is an implementation of Neural Network in Go Language, which includes BPNN, RBF, PCN. **[Deprecated]**
 * [bayesian](https://github.com/jbrukh/bayesian) - Naive Bayesian Classification for Golang. **[Deprecated]**
 * [go-galib](https://github.com/thoj/go-galib) - Genetic Algorithms library written in Go / Golang. **[Deprecated]**
 * [Cloudforest](https://github.com/ryanbressler/CloudForest) - Ensembles of decision trees in Go/Golang. **[Deprecated]**
-* [gobrain](https://github.com/goml/gobrain) - Neural Networks written in Go.
-* [GoNN](https://github.com/fxsjy/gonn) - GoNN is an implementation of Neural Network in Go Language, which includes BPNN, RBF, PCN. **[Deprecated]**
-* [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) - Go binding for MXNet c_predict_api to do inference with pre-trained model.
-* [neat](https://github.com/jinyeom/neat) - Plug-and-play, parallel Go framework for NeuroEvolution of Augmenting Topologies (NEAT). **[Deprecated]**
-* [go-ml-transpiler](https://github.com/znly/go-ml-transpiler) - An open source Go transpiler for machine learning models.
-* [therfoo](https://github.com/therfoo/therfoo) - An embedded deep learning library for Go.
+
+<a name="go-spatial-analysis"></a>
+#### Spatial analysis and geometry
+
+* [go-geom](https://github.com/twpayne/go-geom) - Go library to handle geometries.
+* [gogeo](https://github.com/golang/geo) - Spherical geometry in Go.
 
 <a name="go-data-analysis"></a>
 #### Data Analysis / Data Visualization
 
-* [go-graph](https://github.com/StepLg/go-graph) - Graph library for Go/Golang language. **[Deprecated]**
+* [gota](https://github.com/go-gota/gota) - Dataframes.
+* [gonum/mat](https://godoc.org/gonum.org/v1/gonum/mat) - A linear algebra package for Go.
+* [gonum/optimize](https://godoc.org/gonum.org/v1/gonum/optimize) - Implementations of optimization algorithms.
+* [gonum/plot](https://godoc.org/gonum.org/v1/plot) - A plotting library.
+* [gonum/stat](https://godoc.org/gonum.org/v1/gonum/stat) - A statistics library.
 * [SVGo](https://github.com/ajstarks/svgo) - The Go Language library for SVG generation.
+* [glot](https://github.com/arafatk/glot) - Glot is a plotting library for Golang built on top of gnuplot.
+* [globe](https://github.com/mmcloughlin/globe) - Globe wireframe visualization.
+* [gonum/graph](https://godoc.org/gonum.org/v1/gonum/graph) - General-purpose graph library.
+* [go-graph](https://github.com/StepLg/go-graph) - Graph library for Go/Golang language. **[Deprecated]**
 * [RF](https://github.com/fxsjy/RF.go) - Random forests implementation in Go. **[Deprecated]**
-* [Glot](https://github.com/arafatk/glot) - Glot is a plotting library for Golang built on top of gnuplot. 
 
-<a name="go-facial-recognition"></a>
-#### Facial Detection and Recognition
+<a name="go-computer-vision"></a>
+#### Computer vision 
 
 * [Facebox](https://godoc.org/github.com/machinebox/sdk-go/facebox) - Facial detection and recognition SDK with one-shot teaching from Machine Box
-
-<a name="go-image-classification"></a>
-#### Image Classification
-
-* [Tagbox](https://godoc.org/github.com/machinebox/sdk-go/tagbox) - Image classification SDK with one-shot teaching from Machine Box
+* [GoCV](https://github.com/hybridgroup/gocv) - Package for computer vision using OpenCV 4 and beyond. 
 * [Nudebox](https://godoc.org/github.com/machinebox/sdk-go/nudebox) - Nudity detection from Machine Box
+* [Tagbox](https://godoc.org/github.com/machinebox/sdk-go/tagbox) - Image classification SDK with one-shot teaching from Machine Box
 
 <a name="haskell"></a>
 ## Haskell
@@ -1017,7 +1031,6 @@ be
 * [Netron](https://github.com/lutzroeder/netron) - Visualizer for machine learning models.
 * [Thampi](https://github.com/scoremedia/thampi) - Machine Learning Prediction System on AWS Lambda
 * [MindsDB](https://github.com/mindsdb/mindsdb) - Open Source framework to streamline use of neural networks.
-* [Gorgonia](https://github.com/gorgonia/gorgonia) - Gorgonia is a library that helps facilitate machine learning in Golang.
 * [Microsoft Recommenders](https://github.com/Microsoft/Recommenders): Examples and best practices for building recommendation systems, provided as Jupyter notebooks. The repo contains some of the latest state of the art algorithms from Microsoft Research as well as from other companies and institutions.
 * [StellarGraph](https://github.com/stellargraph/stellargraph): Machine Learning on Graphs, a Python library for machine learning on graph-structured (network-structured) data.
 * [BentoML](https://github.com/bentoml/bentoml): Toolkit for package and deploy machine learning models for serving in production
@@ -1458,4 +1471,4 @@ be
 ## Credits
 
 * Some of the python libraries were cut-and-pasted from [vinta](https://github.com/vinta/awesome-python)
-* The few go reference I found where pulled from [this page](https://github.com/golang/go/wiki/Projects)
+* References for Go were mostly cut-and-pasted from [gopherdata](https://github.com/gopherdata/resources/tree/master/tooling)


### PR DESCRIPTION
- A lot of Go packages are missing from the list; I updated it based on the references found on gopherdata. 
- Gorgonia was mistakenly added in the python section; I moved it back to the Go section. 
- I also reorganized the list to put deprecated packages at the bottom.
- Some links were not working; I corrected this and checked that they all work now.