### PR TITLE
Adding PySS3 to Python's Natural Language Processing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ be
 * [Rosetta](https://github.com/columbia-applied-data-science/rosetta) - Text processing tools and wrappers (e.g. Vowpal Wabbit)
 * [BLLIP Parser](https://pypi.org/project/bllipparser/) - Python bindings for the BLLIP Natural Language Parser (also known as the Charniak-Johnson parser). **[Deprecated]**
 * [PyNLPl](https://github.com/proycon/pynlpl) - Python Natural Language Processing Library. General purpose NLP library for Python. Also contains some specific modules for parsing common NLP formats, most notably for [FoLiA](https://proycon.github.io/folia/), but also ARPA language models, Moses phrasetables, GIZA++ alignments.
+* [PySS3](https://github.com/sergioburdisso/pyss3) - Python package that implements a novel white-box machine learning model for text classification, called SS3. Since SS3 has the ability to visually explain its rationale, this package also comes with easy-to-use interactive visualizations tools ([online demos](http://tworld.io/ss3/)).
 * [python-ucto](https://github.com/proycon/python-ucto) - Python binding to ucto (a unicode-aware rule-based tokenizer for various languages).
 * [python-frog](https://github.com/proycon/python-frog) - Python binding to Frog, an NLP suite for Dutch. (pos tagging, lemmatisation, dependency parsing, NER)
 * [python-zpar](https://github.com/EducationalTestingService/python-zpar) - Python bindings for [ZPar](https://github.com/frcchang/zpar), a statistical part-of-speech-tagger, constiuency parser, and dependency parser for English.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further resources:
 ### Frameworks and Libraries
 <!-- MarkdownTOC depth=4 -->
 
-- [Awesome Machine Learning ![Awesome](https://github.com/sindresorhus/awesome)](#awesome-machine-learning-awesomehttpsgithubcomsindresorhusawesome)
+- [Awesome Machine Learning ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](#awesome-machine-learning-awesomehttpsgithubcomsindresorhusawesome)
   - [Table of Contents](#table-of-contents)
     - [Frameworks and Libraries](#frameworks-and-libraries)
     - [Tools](#tools)


### PR DESCRIPTION
PySS3 is an open-source python package that implements a novel white-box machine learning model (SS3) for text classification. In addition, PySS3 comes with a set of visualizations tools for Explainable Artificial Intelligence (XAI).

Github repo: [https://github.com/sergioburdisso/pyss3](https://github.com/sergioburdisso/pyss3)
Online live demos: [http://tworld.io/ss3/](http://tworld.io/ss3/)
Documentation: [https://pyss3.readthedocs.io](https://pyss3.readthedocs.io)
Paper preprint: [https://arxiv.org/abs/1912.09322](https://arxiv.org/abs/1912.09322)

---

Since I've put a lot of work on this project I know that my opinion could be really really skewed, but I believe that maybe PySS3 deserves a shot... if you have time check it out... I hope you find it worthy of being on this list, that is, I hope you find it ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg) enough :/

Have a nice day! :)

PS: I've also fixed the "Awesome" badge that was at the beginning of the list (the previous link was broken).