### PR TITLE
m2cgen allows the conversion of ML models into native code with zero …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1524,6 +1524,7 @@ be
 * [MLFlow](https://mlflow.org/) - platform to manage the ML lifecycle, including experimentation, reproducibility and deployment. Framework anf language agnostic, take a look at all the built-in integrations.
 * More tools to improve the ML lifecycle: [Catalyst](https://github.com/catalyst-team/catalyst), [PachydermIO](https://www.pachyderm.io/). The following are Github-alike and targetting teams [Weights & Biases](https://www.wandb.com/), [Neptune.Ml](https://neptune.ml/), [Comet.ml](https://www.comet.ml/), [Valohai.ai](https://valohai.com/).
 * [MachineLearningWithTensorFlow2ed](https://www.manning.com/books/machine-learning-with-tensorflow-second-edition) - a book on general purpose machine learning techniques regression, classification, unsupervised clustering, reinforcement learning, auto encoders, convolutional neural networks, RNNs, LSTMs, using TensorFlow 1.14.1.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A tool that allows the conversion of ML models into native code (Java, C, Python, Go, JavaScript, Visual Basic, C#, R, PowerShell, PHP, Dart) with zero dependencies.
 
 <a name="credits"></a>
 ## Credits


### PR DESCRIPTION
…dependencies.

https://github.com/BayesWitnesses/m2cgen

Found this repo a while back and contributed some code to allow the conversion of ML models into Dart code. This tool allows models to be converted with no dependencies.  Currently supports Java, C, Python, Go, JavaScript, Visual Basic, C#, R, PowerShell, PHP, and Dart. It focuses on handling simpler models, but has a wide range of support for models within the scikit-learn ecosystem. More are being added often.

This tool spans multiple languages even though is it written in Python so the Tools - Misc section seems correct. Feel free to move this wherever!