### PR TITLE
Add Lightwood

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ be
 * [Catalyst](https://github.com/catalyst-team/catalyst) - High-level utils for PyTorch DL & RL research. It was developed with a focus on reproducibility, fast experimentation and code/ideas reusing. Being able to research/develop something new, rather than write another regular train loop.
 * [Fastai](https://github.com/fastai/fastai) - High-level wrapper built on the top of Pytorch which supports vision, text, tabular data and collaborative filtering.
 * [scikit-multiflow](https://github.com/scikit-multiflow/scikit-multiflow) - A machine learning framework for multi-output/multi-label and stream data.
+* [Lightwood](https://github.com/mindsdb/lightwood) - A Pytorch based framework that breaks down machine learning problems into smaller blocks that can be glued together seamlessly with objective to build predictive models with one line of code.
 
 
 <a name="python-data-analysis"></a>


### PR DESCRIPTION
This PR adds [lightwood](https://github.com/mindsdb/lightwood) to the Python General-Purpose Machine Learning list.