### PR TITLE
Add CML to tools-misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@ be
 * More tools to improve the ML lifecycle: [Catalyst](https://github.com/catalyst-team/catalyst), [PachydermIO](https://www.pachyderm.io/). The following are Github-alike and targetting teams [Weights & Biases](https://www.wandb.com/), [Neptune.Ml](https://neptune.ml/), [Comet.ml](https://www.comet.ml/), [Valohai.ai](https://valohai.com/).
 * [MachineLearningWithTensorFlow2ed](https://www.manning.com/books/machine-learning-with-tensorflow-second-edition) - a book on general purpose machine learning techniques regression, classification, unsupervised clustering, reinforcement learning, auto encoders, convolutional neural networks, RNNs, LSTMs, using TensorFlow 1.14.1.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A tool that allows the conversion of ML models into native code (Java, C, Python, Go, JavaScript, Visual Basic, C#, R, PowerShell, PHP, Dart) with zero dependencies.
+* [CML](https://github.com/iterative/cml) - A library for doing continuous integration with ML projects. Use GitHub Actions & GitLab CI to train and evaluate models in production like environments and automatically generate visual reports with metrics and graphs in pull/merge requests. Framework & language agnostic.
 
 <a name="credits"></a>
 ## Credits


### PR DESCRIPTION
I'd like to add an open source tool to the misc. tools list. [CML](https://github.com/iterative/cml) is a toolkit for doing ML with continuous integration systems (GitHub Actions & GitLab CI) and autogenerating visual reports about model performance in GitHub/GitLab. 

Thanks for considering! (Note, I am part of the CML team)