### PR TITLE
Clean up TOC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,124 +30,124 @@ Further resources:
     - [Frameworks and Libraries](#frameworks-and-libraries)
     - [Tools](#tools)
   - [APL](#apl)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning)
+      - [General-Purpose Machine Learning](#apl-general-purpose-machine-learning)
   - [C](#c)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-1)
-      - [Computer Vision](#computer-vision)
-  - [C++](#c)
-      - [Computer Vision](#computer-vision-1)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-2)
-      - [Natural Language Processing](#natural-language-processing)
-      - [Speech Recognition](#speech-recognition)
-      - [Sequence Analysis](#sequence-analysis)
-      - [Gesture Detection](#gesture-detection)
+      - [General-Purpose Machine Learning](#c-general-purpose-machine-learning)
+      - [Computer Vision](#c-computer-vision)
+  - [C++](#cpp)
+      - [Computer Vision](#cpp-computer-vision)
+      - [General-Purpose Machine Learning](#cpp-general-purpose-machine-learning)
+      - [Natural Language Processing](#cpp-natural-language-processing)
+      - [Speech Recognition](#cpp-speech-recognition)
+      - [Sequence Analysis](#cpp-sequence-analysis)
+      - [Gesture Detection](#cpp-gesture-detection)
   - [Common Lisp](#common-lisp)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-3)
+      - [General-Purpose Machine Learning](#common-lisp-general-purpose-machine-learning)
   - [Clojure](#clojure)
-      - [Natural Language Processing](#clojure-nlp)
-      - [General-Purpose Machine Learning](#clojure-general-purpose)
+      - [Natural Language Processing](#clojure-natural-language-processing)
+      - [General-Purpose Machine Learning](#clojure-general-purpose-machine-learning)
       - [Deep Learning](#clojure-deep-learning)
-      - [Data Analysis](#clojure-data-analysis)
+      - [Data Analysis](#clojure-data-analysis--data-visualization)
       - [Data Visualization](#clojure-data-visualization)
       - [Interop](#clojure-interop)
       - [Misc](#clojure-misc)
       - [Extra](#clojure-extra)
   - [Crystal](#crystal)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-5)
+      - [General-Purpose Machine Learning](#crystal-general-purpose-machine-learning)
   - [Elixir](#elixir)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-6)
-      - [Natural Language Processing](#natural-language-processing-2)
+      - [General-Purpose Machine Learning](#elixir-general-purpose-machine-learning)
+      - [Natural Language Processing](#elixir-natural-language-processing)
   - [Erlang](#erlang)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-7)
+      - [General-Purpose Machine Learning](#erlang-general-purpose-machine-learning)
   - [Fortran](#fortran)
       - [General-Purpose Machine Learning](#fortran-general-purpose-machine-learning)
       - [Data Analysis / Data Visualization](#fortran-data-analysis-visualization)
   - [Go](#go)
-      - [Natural Language Processing](#natural-language-processing-3)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-8)
-      - [Spatial analysis and geometry](#spatial-analysis-and-geometry)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-1)
-      - [Computer vision](#computer-vision-2)
-      - [Reinforcement learning](#reinforcement-learning)
+      - [Natural Language Processing](#go-natural-language-processing)
+      - [General-Purpose Machine Learning](#go-general-purpose-machine-learning)
+      - [Spatial analysis and geometry](#go-spatial-analysis-and-geometry)
+      - [Data Analysis / Data Visualization](#go-data-analysis--data-visualization)
+      - [Computer vision](#go-computer-vision)
+      - [Reinforcement learning](#go-reinforcement-learning)
   - [Haskell](#haskell)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-9)
+      - [General-Purpose Machine Learning](#haskell-general-purpose-machine-learning)
   - [Java](#java)
-      - [Natural Language Processing](#natural-language-processing-4)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-10)
-      - [Speech Recognition](#speech-recognition-1)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-2)
-      - [Deep Learning](#deep-learning)
+      - [Natural Language Processing](#java-natural-language-processing)
+      - [General-Purpose Machine Learning](#java-general-purpose-machine-learning)
+      - [Speech Recognition](#java-speech-recognition)
+      - [Data Analysis / Data Visualization](#java-data-analysis--data-visualization)
+      - [Deep Learning](#java-deep-learning)
   - [Javascript](#javascript)
-      - [Natural Language Processing](#natural-language-processing-5)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-3)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-11)
-      - [Misc](#misc)
-      - [Demos and Scripts](#demos-and-scripts)
+      - [Natural Language Processing](#javascript-natural-language-processing)
+      - [Data Analysis / Data Visualization](#javascript-data-analysis--data-visualization)
+      - [General-Purpose Machine Learning](#javascript-general-purpose-machine-learning)
+      - [Misc](#javascript-misc)
+      - [Demos and Scripts](#javascript-demos-and-scripts)
   - [Julia](#julia)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-12)
-      - [Natural Language Processing](#natural-language-processing-6)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-4)
-      - [Misc Stuff / Presentations](#misc-stuff--presentations)
+      - [General-Purpose Machine Learning](#julia-general-purpose-machine-learning)
+      - [Natural Language Processing](#julia-natural-language-processing)
+      - [Data Analysis / Data Visualization](#julia-data-analysis--data-visualization)
+      - [Misc Stuff / Presentations](#julia-misc-stuff--presentations)
   - [Lua](#lua)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-13)
-      - [Demos and Scripts](#demos-and-scripts-1)
+      - [General-Purpose Machine Learning](#lua-general-purpose-machine-learning)
+      - [Demos and Scripts](#lua-demos-and-scripts)
   - [Matlab](#matlab)
-      - [Computer Vision](#computer-vision-3)
-      - [Natural Language Processing](#natural-language-processing-7)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-14)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-5)
+      - [Computer Vision](#matlab-computer-vision)
+      - [Natural Language Processing](#matlab-natural-language-processing)
+      - [General-Purpose Machine Learning](#matlab-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#matlab-data-analysis--data-visualization)
   - [.NET](#net)
-      - [Computer Vision](#computer-vision-4)
-      - [Natural Language Processing](#natural-language-processing-8)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-15)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-6)
+      - [Computer Vision](#net-computer-vision)
+      - [Natural Language Processing](#net-natural-language-processing)
+      - [General-Purpose Machine Learning](#net-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#net-data-analysis--data-visualization)
   - [Objective C](#objective-c)
-    - [General-Purpose Machine Learning](#general-purpose-machine-learning-16)
+    - [General-Purpose Machine Learning](#objective-c-general-purpose-machine-learning)
   - [OCaml](#ocaml)
-    - [General-Purpose Machine Learning](#general-purpose-machine-learning-17)
+    - [General-Purpose Machine Learning](#ocaml-general-purpose-machine-learning)
   - [Perl](#perl)
-    - [Data Analysis / Data Visualization](#data-analysis--data-visualization-7)
-    - [General-Purpose Machine Learning](#general-purpose-machine-learning-18)
+    - [Data Analysis / Data Visualization](#perl-data-analysis--data-visualization)
+    - [General-Purpose Machine Learning](#perl-general-purpose-machine-learning)
   - [Perl 6](#perl-6)
-    - [Data Analysis / Data Visualization](#data-analysis--data-visualization-8)
-    - [General-Purpose Machine Learning](#general-purpose-machine-learning-19)
+    - [Data Analysis / Data Visualization](#perl-6-data-analysis--data-visualization)
+    - [General-Purpose Machine Learning](#perl-6-general-purpose-machine-learning)
   - [PHP](#php)
-    - [Natural Language Processing](#natural-language-processing-9)
-    - [General-Purpose Machine Learning](#general-purpose-machine-learning-20)
+    - [Natural Language Processing](#php-natural-language-processing)
+    - [General-Purpose Machine Learning](#php-general-purpose-machine-learning)
   - [Python](#python)
-      - [Computer Vision](#computer-vision-5)
-      - [Natural Language Processing](#natural-language-processing-10)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-21)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-9)
-      - [Misc Scripts / iPython Notebooks / Codebases](#misc-scripts--ipython-notebooks--codebases)
-      - [Neural Networks](#neural-networks)
-      - [Kaggle Competition Source Code](#kaggle-competition-source-code)
-      - [Reinforcement Learning](#reinforcement-learning-1)
+      - [Computer Vision](#python-computer-vision)
+      - [Natural Language Processing](#python-natural-language-processing)
+      - [General-Purpose Machine Learning](#python-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#python-data-analysis--data-visualization)
+      - [Misc Scripts / iPython Notebooks / Codebases](#python-misc-scripts--ipython-notebooks--codebases)
+      - [Neural Networks](#python-neural-networks)
+      - [Kaggle Competition Source Code](#python-kaggle-competition-source-code)
+      - [Reinforcement Learning](#python-reinforcement-learning)
   - [Ruby](#ruby)
-      - [Natural Language Processing](#natural-language-processing-11)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-22)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-10)
-      - [Misc](#misc-1)
+      - [Natural Language Processing](#ruby-natural-language-processing)
+      - [General-Purpose Machine Learning](#ruby-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#ruby-data-analysis--data-visualization)
+      - [Misc](#ruby-misc)
   - [Rust](#rust)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-23)
+      - [General-Purpose Machine Learning](#general-purpose-machine-learning)
   - [R](#r)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-24)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-11)
+      - [General-Purpose Machine Learning](#r-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#r-data-analysis--data-visualization)
   - [SAS](#sas)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-25)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-12)
-      - [Natural Language Processing](#natural-language-processing-12)
-      - [Demos and Scripts](#demos-and-scripts-2)
+      - [General-Purpose Machine Learning](#sas-general-purpose-machine-learning)
+      - [Data Analysis / Data Visualization](#sas-data-analysis--data-visualization)
+      - [Natural Language Processing](#sas-natural-language-processing)
+      - [Demos and Scripts](#sas-demos-and-scripts)
   - [Scala](#scala)
-      - [Natural Language Processing](#natural-language-processing-13)
-      - [Data Analysis / Data Visualization](#data-analysis--data-visualization-13)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-26)
+      - [Natural Language Processing](#scala-natural-language-processing)
+      - [Data Analysis / Data Visualization](#scala-data-analysis--data-visualization)
+      - [General-Purpose Machine Learning](#scala-general-purpose-machine-learning)
   - [Scheme](#scheme)
-      - [Neural Networks](#neural-networks-1)
+      - [Neural Networks](#scheme-neural-networks)
   - [Swift](#swift)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-27)
+      - [General-Purpose Machine Learning](#swift-general-purpose-machine-learning)
   - [TensorFlow](#tensorflow)
-      - [General-Purpose Machine Learning](#general-purpose-machine-learning-28)
+      - [General-Purpose Machine Learning](#tensorflow-general-purpose-machine-learning)
 
 ### [Tools](#tools-1)
 
@@ -162,14 +162,14 @@ Further resources:
 <a name="apl"></a>
 ## APL
 
-<a name="apl-general-purpose"></a>
+<a name="apl-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 * [naive-apl](https://github.com/mattcunningham/naive-apl) - Naive Bayesian Classifier implementation in APL. **[Deprecated]**
 
 <a name="c"></a>
 ## C
 
-<a name="c-general-purpose"></a>
+<a name="c-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 * [Darknet](https://github.com/pjreddie/darknet) - Darknet is an open source neural network framework written in C and CUDA. It is fast, easy to install, and supports CPU and GPU computation.
 * [Recommender](https://github.com/GHamrouni/Recommender) - A C library for product recommendations/suggestions using collaborative filtering (CF).
@@ -178,7 +178,7 @@ Further resources:
 * [cONNXr](https://github.com/alrevuelta/cONNXr) - An `ONNX` runtime written in pure C (99) with zero dependencies focused on small embedded devices. Run inference on your machine learning models no matter which framework you train it with. Easy to install and compiles everywhere, even in very old devices.
 * [libonnx](https://github.com/xboot/libonnx) - A lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 
-<a name="c-cv"></a>
+<a name="c-computer-vision"></a>
 #### Computer Vision
 
 * [CCV](https://github.com/liuliu/ccv) - C-based/Cached/Core Computer Vision Library, A Modern Computer Vision Library.
@@ -187,8 +187,8 @@ Further resources:
 <a name="cpp"></a>
 ## C++
 
-<a name="cpp-cv"></a>
-#### Computer Vision
+<a name="cpp-computer-vision"></a>
+#### Computer Vision 
 
 * [DLib](http://dlib.net/imaging.html) - DLib has C++ and Python interfaces for face detection and training general object detectors.
 * [EBLearn](http://eblearn.sourceforge.net/) - Eblearn is an object-oriented C++ library that implements various machine learning models **[Deprecated]**
@@ -196,7 +196,7 @@ Further resources:
 * [VIGRA](https://github.com/ukoethe/vigra) - VIGRA is a genertic cross-platform C++ computer vision and machine learning library for volumes of arbitrary dimensionality with Python bindings.
 * [Openpose](https://github.com/CMU-Perceptual-Computing-Lab/openpose) - A real-time multi-person keypoint detection library for body, face, hands, and foot estimation
 
-<a name="cpp-general-purpose"></a>
+<a name="cpp-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [BanditLib](https://github.com/jkomiyama/banditlib) - A simple Multi-armed Bandit library. **[Deprecated]**
@@ -239,7 +239,7 @@ Further resources:
 * [Hopsworks](https://github.com/logicalclocks/hopsworks) - A data-intensive platform for AI with the industry's first open-source feature store. The Hopsworks Feature Store provides both a feature warehouse for training and batch based on Apache Hive and a feature serving database, based on MySQL Cluster, for online applications.
 * [Polyaxon](https://github.com/polyaxon/polyaxon) - A platform for reproducible and scalable machine learning and deep learning.
 
-<a name="cpp-nlp"></a>
+<a name="cpp-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [BLLIP Parser](https://github.com/BLLIP/bllip-parser) - BLLIP Natural Language Parser (also known as the Charniak-Johnson parser).
@@ -256,18 +256,18 @@ Further resources:
 #### Speech Recognition
 * [Kaldi](https://github.com/kaldi-asr/kaldi) - Kaldi is a toolkit for speech recognition written in C++ and licensed under the Apache License v2.0. Kaldi is intended for use by speech recognition researchers.
 
-<a name="cpp-sequence"></a>
+<a name="cpp-sequence-analysis"></a>
 #### Sequence Analysis
 * [ToPS](https://github.com/ayoshiaki/tops) - This is an object-oriented framework that facilitates the integration of probabilistic models for sequences over a user defined alphabet. **[Deprecated]**
 
-<a name="cpp-gestures"></a>
+<a name="cpp-gesture-detection"></a>
 #### Gesture Detection
 * [grt](https://github.com/nickgillian/grt) - The Gesture Recognition Toolkit (GRT) is a cross-platform, open-source, C++ machine learning library designed for real-time gesture recognition.
 
 <a name="common-lisp"></a>
 ## Common Lisp
 
-<a name="common-lisp-general-purpose"></a>
+<a name="common-lisp-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [mgl](https://github.com/melisgl/mgl/) - Neural networks (boltzmann machines, feed-forward and recurrent nets), Gaussian Processes.
@@ -279,13 +279,13 @@ Further resources:
 <a name="clojure"></a>
 ## Clojure
 
-<a name="clojure-nlp"></a>
+<a name="clojure-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Clojure-openNLP](https://github.com/dakrone/clojure-opennlp) - Natural Language Processing in Clojure (opennlp).
 * [Infections-clj](https://github.com/r0man/inflections-clj) - Rails-like inflection library for Clojure and ClojureScript.
 
-<a name="clojure-general-purpose"></a>
+<a name="clojure-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [tech.ml](https://github.com/techascent/tech.ml) - A machine learning platform based on tech.ml.dataset, supporting not just ml algorithms, but also relevant ETL processing; wraps multiple machine learning libraries
@@ -310,7 +310,7 @@ Further resources:
 * [Flare](https://github.com/aria42/flare) - Dynamic Tensor Graph library in Clojure (think PyTorch, DynNet, etc.) 
 * [dl4clj](https://github.com/yetanalytics/dl4clj) - Clojure wrapper for Deeplearning4j.
 
-<a name="clojure-data-analysis"></a>
+<a name="clojure-data-analysis--data-visualization"></a>
 #### Data Analysis 
 * [tech.ml.dataset](https://github.com/techascent/tech.ml.dataset) - Clojure dataframe library and pipeline for data processing and machine learning  
 * [Tablecloth](https://github.com/scicloj/tablecloth) - A dataframe grammar wrapping tech.ml.dataset, inspired by several R libraries
@@ -352,7 +352,7 @@ Further resources:
 <a name="crystal"></a>
 ## Crystal
 
-<a name="crystal-general-purpose"></a>
+<a name="crystal-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [machine](https://github.com/mathieulaporte/machine) - Simple machine learning algorithm.
@@ -361,14 +361,14 @@ Further resources:
 <a name="elixir"></a>
 ## Elixir
 
-<a name="elixir-general-purpose"></a>
+<a name="elixir-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Simple Bayes](https://github.com/fredwu/simple_bayes) - A Simple Bayes / Naive Bayes implementation in Elixir.
 * [emel](https://github.com/mrdimosthenis/emel) - A simple and functional machine learning library written in Elixir.
 * [Tensorflex](https://github.com/anshuman23/tensorflex) - Tensorflow bindings for the Elixir programming language.
 
-<a name="elixir-nlp"></a>
+<a name="elixir-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Stemmer](https://github.com/fredwu/stemmer) - An English (Porter2) stemming implementation in Elixir.
@@ -376,7 +376,7 @@ Further resources:
 <a name="erlang"></a>
 ## Erlang
 
-<a name="erlang-general-purpose"></a>
+<a name="erlang-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Disco](https://github.com/discoproject/disco/) - Map Reduce in Erlang. **[Deprecated]**
@@ -398,7 +398,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="go"></a>
 ## Go
 
-<a name="go-nlp"></a>
+<a name="go-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [snowball](https://github.com/tebeka/snowball) - Snowball Stemmer for Go.
@@ -408,7 +408,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [paicehusk](https://github.com/Rookii/paicehusk) - Golang implementation of the Paice/Husk Stemming Algorithm. *[Deprecated]*
 * [go-porterstemmer](https://github.com/reiver/go-porterstemmer) - A native Go clean room implementation of the Porter Stemming algorithm. **[Deprecated]**
 
-<a name="go-general-purpose"></a>
+<a name="go-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [birdland](https://github.com/rlouf/birdland) - A recommendation library in Go.
@@ -433,13 +433,13 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Cloudforest](https://github.com/ryanbressler/CloudForest) - Ensembles of decision trees in Go/Golang. **[Deprecated]**
 * [go-dnn](https://github.com/sudachen/go-dnn) - Deep Neural Networks for Golang (powered by MXNet)
 
-<a name="go-spatial-analysis"></a>
+<a name="go-spatial-analysis-and-geometry"></a>
 #### Spatial analysis and geometry
 
 * [go-geom](https://github.com/twpayne/go-geom) - Go library to handle geometries.
 * [gogeo](https://github.com/golang/geo) - Spherical geometry in Go.
 
-<a name="go-data-analysis"></a>
+<a name="go-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [dataframe-go](https://github.com/rocketlaunchr/dataframe-go) - Dataframes for machine-learning and statistics (similar to pandas).
@@ -468,7 +468,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="haskell"></a>
 ## Haskell
 
-<a name="haskell-general-purpose"></a>
+<a name="haskell-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 * [haskell-ml](https://github.com/ajtulloch/haskell-ml) - Haskell implementations of various ML algorithms. **[Deprecated]**
 * [HLearn](https://github.com/mikeizbicki/HLearn) - a suite of libraries for interpreting machine learning models according to their algebraic structure. **[Deprecated]**
@@ -480,7 +480,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="java"></a>
 ## Java
 
-<a name="java-nlp"></a>
+<a name="java-natural-language-processing"></a>
 #### Natural Language Processing
 * [Cortical.io](https://www.cortical.io/) - Retina: an API performing complex NLP operations (disambiguation, classification, streaming text filtering, etc...) as quickly and intuitively as the brain.
 * [IRIS](https://github.com/cortical-io/Iris) - [Cortical.io's](https://cortical.io) FREE NLP, Retina API Analysis Tool (written in JavaFX!) - [See the Tutorial Video](https://www.youtube.com/watch?v=CsF4pd7fGF0).
@@ -504,7 +504,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [NLP4J](https://github.com/emorynlp/nlp4j) - The NLP4J project provides software and resources for natural language processing. The project started at the Center for Computational Language and EducAtion Research, and is currently developed by the Center for Language and Information Research at Emory University. **[Deprecated]**
 * [CogcompNLP](https://github.com/CogComp/cogcomp-nlp) - This project collects a number of core libraries for Natural Language Processing (NLP) developed in the University of Illinois' Cognitive Computation Group, for example `illinois-core-utilities` which provides a set of NLP-friendly data structures and a number of NLP-related utilities that support writing NLP applications, running experiments, etc, `illinois-edison` a library for feature extraction from illinois-core-utilities data structures and many other packages.
 
-<a name="java-general-purpose"></a>
+<a name="java-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [aerosolve](https://github.com/airbnb/aerosolve) - A machine learning library by Airbnb designed from the ground up to be human friendly.
@@ -537,7 +537,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 #### Speech Recognition
 * [CMU Sphinx](https://cmusphinx.github.io) - Open Source Toolkit For Speech Recognition purely based on Java speech recognition library.
 
-<a name="java-data-analysis"></a>
+<a name="java-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [Flink](https://flink.apache.org/) - Open source platform for distributed stream and batch data processing.
@@ -558,7 +558,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="javascript"></a>
 ## Javascript
 
-<a name="javascript-nlp"></a>
+<a name="javascript-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Twitter-text](https://github.com/twitter/twitter-text) - A JavaScript implementation of Twitter's text processing library.
@@ -570,7 +570,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 
 
 
-<a name="javascript-data-analysis"></a>
+<a name="javascript-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [D3.js](https://d3js.org/)
@@ -596,7 +596,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Nivo](https://nivo.rocks) - built on top of the awesome d3 and Reactjs libraries
 
 
-<a name="javascript-general-purpose"></a>
+<a name="javascript-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Auto ML](https://github.com/ClimbsRocks/auto_ml) - Automated machine learning, data formatting, ensembling, and hyperparameter optimization for competitions and exploration- just give it a .csv file!
@@ -645,7 +645,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [MLPleaseHelp](https://github.com/jgreenemi/MLPleaseHelp) - MLPleaseHelp is a simple ML resource search engine. You can use this search engine right now at [https://jgreenemi.github.io/MLPleaseHelp/](https://jgreenemi.github.io/MLPleaseHelp/), provided via Github Pages.
 * [Pipcook](https://github.com/alibaba/pipcook) - A JavaScript application framework for machine learning and its engineering.
 
-<a name="javascript-demos"></a>
+<a name="javascript-demos-and-scripts"></a>
 #### Demos and Scripts
 * [The Bot](https://github.com/sta-ger/TheBot) - Example of how the neural network learns to predict the angle between two points created with [Synaptic](https://github.com/cazala/synaptic).
 * [Half Beer](https://github.com/sta-ger/HalfBeer) - Beer glass classifier created with [Synaptic](https://github.com/cazala/synaptic).
@@ -655,7 +655,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="julia"></a>
 ## Julia
 
-<a name="julia-general-purpose"></a>
+<a name="julia-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [MachineLearning](https://github.com/benhamner/MachineLearning.jl) - Julia Machine Learning library. **[Deprecated]**
@@ -694,7 +694,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Flux](https://fluxml.ai/) - Relax! Flux is the ML library that doesn't make you tensor
 * [MLJ](https://github.com/alan-turing-institute/MLJ.jl) - A Julia machine learning framework
 
-<a name="julia-nlp"></a>
+<a name="julia-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Topic Models](https://github.com/slycoder/TopicModels.jl) - TopicModels for Julia. **[Deprecated]**
@@ -705,7 +705,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Languages](https://github.com/JuliaText/Languages.jl) - Julia package for working with various human languages
 * [WordNet](https://github.com/JuliaText/WordNet.jl) - A Julia package for Princeton's WordNet
 
-<a name="julia-data-analysis"></a>
+<a name="julia-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [Graph Layout](https://github.com/IainNZ/GraphLayout.jl) - Graph layout algorithms in pure Julia.
@@ -723,7 +723,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Time Series](https://github.com/JuliaStats/TimeSeries.jl) - Time series toolkit for Julia.
 * [Sampling](https://github.com/lindahua/Sampling.jl) - Basic sampling algorithms for Julia.
 
-<a name="julia-misc"></a>
+<a name="julia-misc-stuff--presentations"></a>
 #### Misc Stuff / Presentations
 
 * [DSP](https://github.com/JuliaDSP/DSP.jl) - Digital Signal Processing (filtering, periodograms, spectrograms, window functions).
@@ -735,7 +735,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="lua"></a>
 ## Lua
 
-<a name="lua-general-purpose"></a>
+<a name="lua-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Torch7](http://torch.ch/)
@@ -777,7 +777,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Lua - Numerical Algorithms](https://bitbucket.org/lucashnegri/lna) **[Deprecated]**
 * [Lunum](https://github.com/jzrake/lunum) **[Deprecated]**
 
-<a name="lua-demos"></a>
+<a name="lua-demos-and-scripts"></a>
 #### Demos and Scripts
 * [Core torch7 demos repository](https://github.com/e-lab/torch7-demos).
   * linear-regression, logistic-regression
@@ -808,7 +808,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 <a name="matlab"></a>
 ## Matlab
 
-<a name="matlab-cv"></a>
+<a name="matlab-computer-vision"></a>
 #### Computer Vision
 
 * [Contourlets](http://www.ifp.illinois.edu/~minhdo/software/contourlet_toolbox.tar) - MATLAB source code that implements the contourlet transform and its utility functions.
@@ -817,12 +817,12 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Bandlets](http://www.cmap.polytechnique.fr/~peyre/download/) - MATLAB code for bandlet transform.
 * [mexopencv](https://kyamagu.github.io/mexopencv/) - Collection and a development kit of MATLAB mex functions for OpenCV library.
 
-<a name="matlab-nlp"></a>
+<a name="matlab-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [NLP](https://amplab.cs.berkeley.edu/an-nlp-library-for-matlab/) - A NLP library for Matlab.
 
-<a name="matlab-general-purpose"></a>
+<a name="matlab-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Training a deep autoencoder or a classifier
@@ -842,7 +842,7 @@ on MNIST digits[DEEP LEARNING].
 * [Machine Learning in MatLab/Octave](https://github.com/trekhleb/machine-learning-octave) - examples of popular machine learning algorithms (neural networks, linear/logistic regressions, K-Means, etc.) with code examples and mathematics behind them being explained.
 
 
-<a name="matlab-data-analysis"></a>
+<a name="matlab-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [ParaMonte](https://github.com/cdslaborg/paramonte) - A general-purpose MATLAB library for Bayesian data analysis and visualization via serial/parallel Monte Carlo and MCMC simulations. Documentation can be found [here](https://www.cdslab.org/paramonte/).
@@ -852,7 +852,7 @@ on MNIST digits[DEEP LEARNING].
 <a name="net"></a>
 ## .NET
 
-<a name="net-cv"></a>
+<a name="net-computer-vision"></a>
 #### Computer Vision
 
 * [OpenCVDotNet](https://code.google.com/archive/p/opencvdotnet) - A wrapper for the OpenCV project to be used with .NET applications.
@@ -860,12 +860,12 @@ on MNIST digits[DEEP LEARNING].
 * [AForge.NET](http://www.aforgenet.com/framework/) - Open source C# framework for developers and researchers in the fields of Computer Vision and Artificial Intelligence. Development has now shifted to GitHub.
 * [Accord.NET](http://accord-framework.net) - Together with AForge.NET, this library can provide image processing and computer vision algorithms to Windows, Windows RT and Windows Phone. Some components are also available for Java and Android.
 
-<a name="net-nlp"></a>
+<a name="net-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Stanford.NLP for .NET](https://github.com/sergey-tihon/Stanford.NLP.NET/) - A full port of Stanford NLP packages to .NET and also available precompiled as a NuGet package.
 
-<a name="net-general-purpose"></a>
+<a name="net-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Accord-Framework](http://accord-framework.net/) -The Accord.NET Framework is a complete framework for building machine learning, computer vision, computer audition, signal processing and statistical applications.
@@ -880,17 +880,17 @@ on MNIST digits[DEEP LEARNING].
 * [Vulpes](https://github.com/fsprojects/Vulpes) - Deep belief and deep learning implementation written in F# and leverages CUDA GPU execution with Alea.cuBase.
 * [MxNet.Sharp](https://github.com/tech-quantum/MxNet.Sharp) - .NET Standard bindings for Apache MxNet with Imperative, Symbolic and Gluon Interface for developing, training and deploying Machine Learning models in C#. https://mxnet.tech-quantum.com/
 
-<a name="net-data-analysis"></a>
+<a name="net-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [numl](https://www.nuget.org/packages/numl/) - numl is a machine learning library intended to ease the use of using standard modeling techniques for both prediction and clustering.
 * [Math.NET Numerics](https://www.nuget.org/packages/MathNet.Numerics/) - Numerical foundation of the Math.NET project, aiming to provide methods and algorithms for numerical computations in science, engineering and everyday use. Supports .Net 4.0, .Net 3.5 and Mono on Windows, Linux and Mac; Silverlight 5, WindowsPhone/SL 8, WindowsPhone 8.1 and Windows 8 with PCL Portable Profiles 47 and 344; Android/iOS with Xamarin.
 * [Sho](https://www.microsoft.com/en-us/research/project/sho-the-net-playground-for-data/) - Sho is an interactive environment for data analysis and scientific computing that lets you seamlessly connect scripts (in IronPython) with compiled code (in .NET) to enable fast and flexible prototyping. The environment includes powerful and efficient libraries for linear algebra as well as data visualization that can be used from any .NET language, as well as a feature-rich interactive shell for rapid development.
 
-<a name="objectivec"></a>
+<a name="objective-c"></a>
 ## Objective C
 
-<a name="objectivec-general-purpose"></a>
+<a name="objective-c-general-purpose-machine-learning"></a>
 ### General-Purpose Machine Learning
 
 * [YCML](https://github.com/yconst/YCML) - A Machine Learning framework for Objective-C and Swift (OS X / iOS).
@@ -905,7 +905,7 @@ on MNIST digits[DEEP LEARNING].
 <a name="ocaml"></a>
 ## OCaml
 
-<a name="ocaml-general-purpose"></a>
+<a name="ocaml-general-purpose-machine-learning"></a>
 ### General-Purpose Machine Learning
 
 * [Oml](https://github.com/rleonid/oml) - A general statistics and machine learning library.
@@ -916,13 +916,13 @@ on MNIST digits[DEEP LEARNING].
 <a name="perl"></a>
 ## Perl
 
-<a name="perl-data"></a>
+<a name="perl-data-analysis--data-visualization"></a>
 ### Data Analysis / Data Visualization
 
 * [Perl Data Language](https://metacpan.org/pod/Paws::MachineLearning), a pluggable architecture for data and image processing, which can
 be [used for machine learning](https://github.com/zenogantner/PDL-ML).
 
-<a name="perl-ml"></a>
+<a name="perl-general-purpose-machine-learning"></a>
 ### General-Purpose Machine Learning
 
 * [MXnet for Deep Learning, in Perl](https://github.com/apache/incubator-mxnet/tree/master/perl-package),
@@ -942,6 +942,7 @@ using AWS machine learning platform from Perl.
 * [Support Vector Machines](https://github.com/titsuki/p6-Algorithm-LibSVM)
 * [Naïve Bayes](https://github.com/titsuki/p6-Algorithm-NaiveBayes)
 
+<a name="perl-6-data-analysis--data-visualization"></a>
 ### Data Analysis / Data Visualization
 
 * [Perl Data Language](https://metacpan.org/pod/Paws::MachineLearning),
@@ -949,17 +950,18 @@ a pluggable architecture for data and image processing, which can
 be
 [used for machine learning](https://github.com/zenogantner/PDL-ML).
 
+<a name="perl-6-general-purpose-machine-learning"></a>
 ### General-Purpose Machine Learning
 
 <a name="php"></a>
 ## PHP
 
-<a name="php-nlp"></a>
+<a name="php-natural-language-processing"></a>
 ### Natural Language Processing
 
 * [jieba-php](https://github.com/fukuball/jieba-php) - Chinese Words Segmentation Utilities.
 
-<a name="php-general-purpose"></a>
+<a name="php-general-purpose-machine-learning"></a>
 ### General-Purpose Machine Learning
 
 * [PHP-ML](https://gitlab.com/php-ai/php-ml) - Machine Learning library for PHP. Algorithms, Cross Validation, Neural Network, Preprocessing, Feature Extraction and much more in one library.
@@ -970,7 +972,7 @@ be
 <a name="python"></a>
 ## Python
 
-<a name="python-cv"></a>
+<a name="python-computer-vision"></a>
 #### Computer Vision
 
 * [Scikit-Image](https://github.com/scikit-image/scikit-image) - A collection of algorithms for image processing in Python.
@@ -998,7 +1000,7 @@ be
 * [lightly](https://github.com/lightly-ai/lightly) - Lightly is a computer vision framework for self-supervised learning.
 * [Learnergy](https://github.com/gugarosa/learnergy) - Energy-based machine learning models built upon PyTorch.
 
-<a name="python-nlp"></a>
+<a name="python-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [pkuseg-python](https://github.com/lancopku/pkuseg-python) - A better version of Jieba, developed by Peking University.
@@ -1042,7 +1044,7 @@ be
 * [BigARTM](https://github.com/bigartm/bigartm) - topic modelling platform.
 * [NALP](https://github.com/gugarosa/nalp) - A Natural Adversarial Language Processing framework built over Tensorflow.
 
-<a name="python-general-purpose"></a>
+<a name="python-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
  * [Shapley](https://github.com/benedekrozemberczki/shapley) -> A data-driven framework to quantify the value of classifiers in a machine learning ensemble. 
@@ -1173,7 +1175,7 @@ be
 * [Opytimizer](https://github.com/gugarosa/opytimizer) - Python-based meta-heuristic optimization techniques. 
 * [Gradio](https://github.com/gradio-app/gradio) - A Python library for quickly creating and sharing demos of models. Debug models interactively in your browser, get feedback from collaborators, and generate public links without deploying anything.
 
-<a name="python-data-analysis"></a>
+<a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 * [DataVisualization](https://github.com/Shanky-21/Data_visualization) - A Github Repository Where you can Learn Datavisualizatoin Basics to Intermediate level.
 * [Cartopy](https://scitools.org.uk/cartopy/docs/latest/) - Cartopy is a Python package designed for geospatial data processing in order to produce maps and other geospatial data analyses.
@@ -1232,7 +1234,7 @@ be
 * [TensorWatch](https://github.com/microsoft/tensorwatch) - Debugging and visualization tool for machine learning and data science. It extensively leverages Jupyter Notebook to show real-time visualizations of data in running processes such as machine learning training.
 * [dowel](https://github.com/rlworkgroup/dowel) - A little logger for machine learning research. Output any object to the terminal, CSV, TensorBoard, text logs on disk, and more with just one call to `logger.log()`.
 
-<a name="python-misc"></a>
+<a name="python-misc-scripts--ipython-notebooks--codebases"></a>
 #### Misc Scripts / iPython Notebooks / Codebases
 * [MiniGrad](https://github.com/kennysong/minigrad) – A minimal, educational, Pythonic implementation of autograd (~100 loc).
 * [Map/Reduce implementations of common ML algorithms](https://github.com/Yannael/BigDataAnalytics_INFOH515): Jupyter notebooks that cover how to implement from scratch different ML algorithms (ordinary least squares, gradient descent, k-means, alternating least squares), using Python NumPy, and how to then make these implementations scalable using Map/Reduce and Spark.
@@ -1297,7 +1299,7 @@ be
 * [Jina AI](https://jina.ai/) An easier way to build neural search in the cloud. Compatible with Jupyter Notebooks. 
 
 
-<a name="python-kaggle"></a>
+<a name="python-kaggle-competition-source-code"></a>
 #### Kaggle Competition Source Code
 * [open-solution-home-credit](https://github.com/neptune-ml/open-solution-home-credit) -> source code and [experiments results](https://app.neptune.ml/neptune-ml/Home-Credit-Default-Risk) for [Home Credit Default Risk](https://www.kaggle.com/c/home-credit-default-risk).
 * [open-solution-googleai-object-detection](https://github.com/neptune-ml/open-solution-googleai-object-detection) -> source code and [experiments results](https://app.neptune.ml/neptune-ml/Google-AI-Object-Detection-Challenge) for [Google AI Open Images - Object Detection Track](https://www.kaggle.com/c/google-ai-open-images-object-detection-track).
@@ -1342,7 +1344,7 @@ be
 <a name="ruby"></a>
 ## Ruby
 
-<a name="ruby-nlp"></a>
+<a name="ruby-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Awesome NLP with Ruby](https://github.com/arbox/nlp-with-ruby) - Curated link list for practical natural language processing in Ruby.
@@ -1352,7 +1354,7 @@ be
 * [UEA Stemmer](https://github.com/ealdent/uea-stemmer) - Ruby port of UEALite Stemmer - a conservative stemmer for search and indexing.
 * [Twitter-text-rb](https://github.com/twitter/twitter-text/tree/master/rb) - A library that does auto linking and extraction of usernames, lists and hashtags in tweets.
 
-<a name="ruby-general-purpose"></a>
+<a name="ruby-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Awesome Machine Learning with Ruby](https://github.com/arbox/machine-learning-with-ruby) - Curated list of ML related resources for Ruby.
@@ -1364,7 +1366,7 @@ be
 * [Scoruby](https://github.com/asafschers/scoruby) - Creates Random Forest classifiers from PMML files.
 * [rumale](https://github.com/yoshoku/rumale) - Rumale is a machine learning library in Ruby
 
-<a name="ruby-data-analysis"></a>
+<a name="ruby-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [rsruby](https://github.com/alexgutteridge/rsruby) - Ruby - R bridge.
@@ -1387,7 +1389,7 @@ be
 <a name="rust"></a>
 ## Rust
 
-<a name="rust-general-purpose"></a>
+<a name="rust-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 * [deeplearn-rs](https://github.com/tedsta/deeplearn-rs) - deeplearn-rs provides simple networks that use matrix multiplication, addition, and ReLU under the MIT license.
 * [rustlearn](https://github.com/maciejkula/rustlearn) - a machine learning framework featuring logistic regression, support vector machines, decision trees and random forests.
@@ -1400,7 +1402,7 @@ be
 <a name="r"></a>
 ## R
 
-<a name="r-general-purpose"></a>
+<a name="r-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [ahaz](https://cran.r-project.org/web/packages/ahaz/index.html) - ahaz: Regularization for semiparametric additive hazards regression. **[Deprecated]**
@@ -1489,7 +1491,7 @@ be
 * [MXNet](https://github.com/apache/incubator-mxnet) - Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler; for Python, R, Julia, Go, Javascript and more.
 * [TDSP-Utilities](https://github.com/Azure/Azure-TDSP-Utilities) - Two data science utilities in R from Microsoft: 1) Interactive Data Exploration, Analysis, and Reporting (IDEAR) ; 2) Automated Modeling and Reporting (AMR).
 
-<a name="r-data-analysis"></a>
+<a name="r-data-analysis--data-visualization"></a>
 #### Data Manipulation | Data Analysis | Data Visualization
 
 * [dplyr](https://www.rdocumentation.org/packages/dplyr/versions/0.7.8) - A data manipulation package that helps to solve the most common data manipulation problems.
@@ -1501,27 +1503,27 @@ be
 <a name="sas"></a>
 ## SAS
 
-<a name="sas-general-purpose"></a>
+<a name="sas-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Visual Data Mining and Machine Learning](https://www.sas.com/en_us/software/visual-data-mining-machine-learning.html) - Interactive, automated, and programmatic modeling with the latest machine learning algorithms in and end-to-end analytics environment, from data prep to deployment. Free trial available.
 * [Enterprise Miner](https://www.sas.com/en_us/software/enterprise-miner.html) - Data mining and machine learning that creates deployable models using a GUI or code.
 * [Factory Miner](https://www.sas.com/en_us/software/factory-miner.html) - Automatically creates deployable machine learning models across numerous market or customer segments using a GUI.
 
-<a name="sas-data-analysis"></a>
+<a name="sas-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [SAS/STAT](https://www.sas.com/en_us/software/stat.html) - For conducting advanced statistical analysis.
 * [University Edition](https://www.sas.com/en_us/software/university-edition.html) - FREE! Includes all SAS packages necessary for data analysis and visualization, and includes online SAS courses.
 
-<a name="sas-nlp"></a>
+<a name="sas-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [Contextual Analysis](https://www.sas.com/en_us/software/contextual-analysis.html) - Add structure to unstructured text using a GUI.
 * [Sentiment Analysis](https://www.sas.com/en_us/software/sentiment-analysis.html) - Extract sentiment from text using a GUI.
 * [Text Miner](https://www.sas.com/en_us/software/text-miner.html) - Text mining using a GUI or code.
 
-<a name="sas-demos"></a>
+<a name="sas-demos-and-scripts"></a>
 #### Demos and Scripts
 
 * [ML_Tables](https://github.com/sassoftware/enlighten-apply/tree/master/ML_tables) - Concise cheat sheets containing machine learning best practices.
@@ -1534,7 +1536,7 @@ be
 <a name="scala"></a>
 ## Scala
 
-<a name="scala-nlp"></a>
+<a name="scala-natural-language-processing"></a>
 #### Natural Language Processing
 
 * [ScalaNLP](http://www.scalanlp.org/) - ScalaNLP is a suite of machine learning and numerical computing libraries.
@@ -1544,7 +1546,7 @@ be
 * [Montague](https://github.com/Workday/upshot-montague) - Montague is a semantic parsing library for Scala with an easy-to-use DSL.
 * [Spark NLP](https://github.com/JohnSnowLabs/spark-nlp) - Natural language processing library built on top of Apache Spark ML to provide simple, performant, and accurate NLP annotations for machine learning pipelines, that scale easily in a distributed environment.
 
-<a name="scala-data-analysis"></a>
+<a name="scala-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization
 
 * [MLlib in Apache Spark](https://spark.apache.org/docs/latest/mllib-guide.html) - Distributed machine learning library in Spark
@@ -1558,7 +1560,7 @@ be
 * [Flink](https://flink.apache.org/) - Open source platform for distributed stream and batch data processing.
 * [Spark Notebook](http://spark-notebook.io) - Interactive and Reactive Data Science using Scala and Spark.
 
-<a name="scala-general-purpose"></a>
+<a name="scala-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [DeepLearning.scala](https://deeplearning.thoughtworks.school/) - Creating statically typed dynamic neural networks from object-oriented & functional programming constructs.
@@ -1589,7 +1591,7 @@ be
 <a name="swift"></a>
 ## Swift
 
-<a name="swift-general-purpose"></a>
+<a name="swift-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
 * [Bender](https://github.com/xmartlabs/Bender) - Fast Neural Networks framework built on top of Metal. Supports TensorFlow models.
@@ -1605,10 +1607,10 @@ be
 * [Awesome CoreML](https://github.com/SwiftBrain/awesome-CoreML-models) - A curated list of pretrained CoreML models.
 * [Awesome Core ML Models](https://github.com/likedan/Awesome-CoreML-Models) - A curated list of machine learning models in CoreML format.
 
-<a name="tensor"></a>
+<a name="tensorflow"></a>
 ## TensorFlow
 
-<a name="tensor-general-purpose"></a>
+<a name="tensorflow-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 * [Awesome TensorFlow](https://github.com/jtoy/awesome-tensorflow) - A list of all things related to TensorFlow.
 * [Golden TensorFlow](https://golden.com/wiki/TensorFlow) - A page of content on TensorFlow, including academic papers and links to related topics.


### PR DESCRIPTION
Many of the TOC links linked to either the wrong section (due to numbering issues, etc) or no section at all (due to mismatches between the <a> tag and the markdown link). See for example any of the Julia links, which link to JavaScript sections.

This PR cleans up the link naming system by replacing the numbering system with a standardized system of programming-language-section-name. It updates all of the TOC links so that they now link to the correct sections.