### PR TITLE
Remove Music Tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,7 +797,6 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
   * filter-bank visualization
   * saliency-networks
 * [Training a Convnet for the Galaxy-Zoo Kaggle challenge(CUDA demo)](https://github.com/soumith/galaxyzoo)
-* [Music Tagging](https://github.com/mbhenaff/MusicTagging) - Music Tagging scripts for torch7.
 * [torch-datasets](https://github.com/rosejn/torch-datasets) - Scripts to load several popular datasets including:
   * BSR 500
   * CIFAR-10


### PR DESCRIPTION
I happened to notice that the Music Tagging link https://github.com/mbhenaff/MusicTagging is broken, so suggesting that the project be removed. I am not familiar with the MusicTagging project, but I searched for repos with the same name and did find [this repo](https://github.com/nikhilagrima/MusicTagging) which looks like it might be related, although it doesn't seem to be actively maintained.