### PR TITLE
Add dirty_cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ be
 * [Shapash](https://github.com/MAIF/shapash) : Shapash is a Python library that provides several types of visualization that display explicit labels that everyone can understand.
 * [Eurybia](https://github.com/MAIF/eurybia): Eurybia monitors data and model drift over time and securizes model deployment with data validation.
 * [Colossal-AI](https://github.com/hpcaitech/ColossalAI): An open-source deep learning system for large-scale model training and inference with high efficiency and low cost.
+* dirty_cat](https://github.com/dirty-cat/dirty_cat) - facilitates machine-learning on dirty, non-curated categories. It provides transformers and encoders robust to morphological variants, such as typos.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Adds [dirty_cat](https://github.com/dirty-cat/dirty_cat), a library for machine learning on dirty, non curated data.
It provides encoders robust to morphological variants, such as typos.

See [this video](https://youtu.be/_GNaaeEI2tg) for an introduction ; you can also check out the research papers that gave birth to the library : [[1]](https://hal.inria.fr/hal-01806175) [[2]](https://hal.inria.fr/hal-02171256v4)
Additional info & examples are available on the [official website](https://dirty-cat.github.io/stable/) :)

Cheers !