### PR TITLE
Add Practical Gradient Boosting

### DIFF
--- a/books.md
+++ b/books.md
@@ -101,6 +101,8 @@ The following is a list of free and/or open source books on machine learning, st
 * [Natural Language Processing in Action, Second Edition](https://www.manning.com/books/natural-language-processing-in-action-second-edition) Early access book
 * [Getting Started with Natural Language Processing in Action](https://www.manning.com/books/getting-started-with-natural-language-processing) Early access book
 * [Transfer Learnin for Natural Language Processing](https://www.manning.com/books/transfer-learning-for-natural-language-processing) by Paul Azunre
+* [Practical Gradient Boosting](https://www.amazon.com/dp/B0BL1HRD6Z) by Guillaume Saupin
+
 
 ## Information Retrieval
 


### PR DESCRIPTION
Hello,

I'd like to add my book on gradient boosting in the book section.

It's the English edition of my book `Gradient Boosting`, published by the Editions Eni: https://www.editions-eni.fr/livre/gradient-boosting-exploitez-les-arbres-de-decision-pour-le-machine-learning-xgboost-catboost-lightgbm-9782409034022

I think it's a valuable resource for learning gradient boosting (XGBoost, LightGBM, CatBoost, ...)