### PR TITLE
Previous link was broken

### DIFF
--- a/books.md
+++ b/books.md
@@ -146,4 +146,4 @@ The following is a list of free and/or open source books on machine learning, st
 
 * [Calculus Made Easy](https://github.com/lahorekid/Calculus/blob/master/Calculus%20Made%20Easy.pdf)
 * [calculus by ron larson](https://www.pdfdrive.com/calculus-e183995561.html)
-* ["Active Calculus" by Matt Boelkins](https://scholarworks.gvsu.edu/books/20/)
+* [Active Calculus by Matt Boelkins](https://scholarworks.gvsu.edu/books/20/)

--- a/books.md
+++ b/books.md
@@ -145,4 +145,5 @@ The following is a list of free and/or open source books on machine learning, st
 ## Calculus
 
 * [Calculus Made Easy](https://github.com/lahorekid/Calculus/blob/master/Calculus%20Made%20Easy.pdf)
-* [calculus by ron larson](https://www.spps.org/cms/lib/MN01910242/Centricity/Domain/860/%20CalculusTextbook.pdf)
+* [calculus by ron larson](https://www.pdfdrive.com/calculus-e183995561.html)
+* ["Active Calculus" by Matt Boelkins](https://scholarworks.gvsu.edu/books/20/)


### PR DESCRIPTION
Link  to [calculus by ron larson](https://www.spps.org/cms/lib/MN01910242/Centricity/Domain/860/%20CalculusTextbook.pdf) was BROKEN, hence added the correct link, also added a new book for Calculus with the correct link.