### PR TITLE
Add MCP Memory Service to Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ be
 * [Towhee](https://towhee.io) - A Python module that encode unstructured data into embeddings.
 * [scikit-learn](https://scikit-learn.org/) - A Python module for machine learning built on top of SciPy.
 * [metric-learn](https://github.com/metric-learn/metric-learn) - A Python module for metric learning.
+* [MCP Memory Service](https://github.com/doobidoo/mcp-memory-service) - Universal memory service with semantic search, autonomous consolidation, and multi-client support for AI applications.
 * [OpenMetricLearning](https://github.com/OML-Team/open-metric-learning) - A PyTorch-based framework to train and validate the models producing high-quality embeddings.
 * [Intel(R) Extension for Scikit-learn](https://github.com/intel/scikit-learn-intelex) - A seamless way to speed up your Scikit-learn applications with no accuracy loss and code changes.
 * [SimpleAI](https://github.com/simpleai-team/simpleai) Python implementation of many of the artificial intelligence algorithms described in the book "Artificial Intelligence, a Modern Approach". It focuses on providing an easy to use, well documented and tested library.


### PR DESCRIPTION
Hello! I'd like to add MCP Memory Service to the Python General-Purpose Machine Learning section.

**About MCP Memory Service:**
MCP Memory Service is a universal memory service that provides semantic search, autonomous memory consolidation, and multi-client support for AI applications and ML development environments.

**Why it fits in this section:**
- Uses sentence transformers and vector embeddings for semantic search
- Implements ML-inspired autonomous memory consolidation algorithms  
- Built on PyTorch with support for CUDA, MPS, DirectML, ROCm
- Provides intelligent memory capabilities for ML development workflows
- Production-ready with SQLite-vec and ChromaDB backends

**Repository Details:**
- Language: Python 3.10+
- Dependencies: sentence-transformers, PyTorch, FastAPI
- License: Apache 2.0
- Status: Actively maintained with regular updates

The project has been in development for several months, is production-ready, and provides valuable ML infrastructure for the Python ecosystem.

Thank you for considering this addition!