### PR TITLE
Add Neurolink to Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,6 +1202,7 @@ be
 * [pyhsmm](https://github.com/mattjj/pyhsmm) - library for approximate unsupervised inference in Bayesian Hidden Markov Models (HMMs) and explicit-duration Hidden semi-Markov Models (HSMMs), focusing on the Bayesian Nonparametric extensions, the HDP-HMM and HDP-HSMM, mostly with weak-limit approximations.
 * [SKLL](https://github.com/EducationalTestingService/skll) - A wrapper around scikit-learn that makes it simpler to conduct experiments.
 * [neurolab](https://github.com/zueve/neurolab)
+* [Neurolink](https://github.com/juspay/neurolink) - Multi-provider AI agent framework with workflow orchestration capabilities, unifying 12+ providers with edge-first architecture. Production-grade platform handling 15M+ requests/month at Juspay.
 * [Spearmint](https://github.com/HIPS/Spearmint) - Spearmint is a package to perform Bayesian optimization according to the algorithms outlined in the paper: Practical Bayesian Optimization of Machine Learning Algorithms. Jasper Snoek, Hugo Larochelle and Ryan P. Adams. Advances in Neural Information Processing Systems, 2012. **[Deprecated]**
 * [Pebl](https://github.com/abhik/pebl/) - Python Environment for Bayesian Learning. **[Deprecated]**
 * [Theano](https://github.com/Theano/Theano/) - Optimizing GPU-meta-programming code generating array oriented optimizing math compiler in Python.


### PR DESCRIPTION
## Summary

Adding **Neurolink** to the Python > General-Purpose Machine Learning section.

**Neurolink** is a production-grade multi-provider AI agent framework with workflow orchestration capabilities that unifies 12+ AI providers (OpenAI, Google, Anthropic, AWS, Azure, Groq, Together AI, Mistral, Cohere, Fireworks, Cloudflare, Ollama) under one API.

- **Repository**: https://github.com/juspay/neurolink
- **Category**: Python > General-Purpose Machine Learning
- **Production Usage**: 15M+ requests/month at Juspay
- **Key Features**: Multi-agent framework, workflow orchestration, multi-provider support, edge-first deployment, streaming, tool calling, Redis caching, enterprise features

Neurolink fits alongside other ML frameworks in this section as a production-ready platform for building AI agent applications.