### PR TITLE
Add Neurolink to Python > General-Purpose Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,7 @@ be
 * [graphlab-create](https://turi.com/products/create/docs/) - A library with various machine learning models (regression, clustering, recommender systems, graph analytics, etc.) implemented on top of a disk-backed DataFrame.
 * [BigML](https://bigml.com) - A library that contacts external servers.
 * [pattern](https://github.com/clips/pattern) - Web mining module for Python.
+* [Neurolink](https://github.com/juspay/neurolink) - Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support.
 * [NuPIC](https://github.com/numenta/nupic) - Numenta Platform for Intelligent Computing.
 * [Pylearn2](https://github.com/lisa-lab/pylearn2) - A Machine Learning library based on [Theano](https://github.com/Theano/Theano). **[Deprecated]**
 * [keras](https://github.com/keras-team/keras) - High-level neural networks frontend for [TensorFlow](https://github.com/tensorflow/tensorflow), [CNTK](https://github.com/Microsoft/CNTK) and [Theano](https://github.com/Theano/Theano).


### PR DESCRIPTION
## Summary
- Add Neurolink to the Python > General-Purpose Machine Learning section
- Enterprise-grade LLM integration framework for production AI applications
- Features built-in hallucination prevention, RAG, and MCP support

## Test plan
- Verify the link works correctly
- Check that the formatting matches existing entries
- Ensure alphabetical placement is correct