### PR TITLE
Add VeritasGraph to Python Natural Language Processing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,7 @@ be
 * [CometLLM](https://github.com/comet-ml/comet-llm) - Track, log, visualize and evaluate your LLM prompts and prompt chains.
 * [Transformers](https://github.com/huggingface/transformers) - A deep learning library containing thousands of pre-trained models on different tasks. The goto place for anything related to Large Language Models.
 * [TextCL](https://github.com/alinapetukhova/textcl) - Text preprocessing package for use in NLP tasks.
+* [VeritasGraph](https://github.com/bibinprathap/VeritasGraph) - Enterprise-Grade Graph RAG for Secure, On-Premise AI with Verifiable Attribution.
 
 <a name="python-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning


### PR DESCRIPTION
Hello!

I would like to add `VeritasGraph` to the awesome-machine-learning list.

* **Repository:** https://github.com/bibinprathap/VeritasGraph
* **Category:** Python > Natural Language Processing
* **Description:** Enterprise-Grade Graph RAG for Secure, On-Premise AI with Verifiable Attribution.

The library is active and relevant to the Graph RAG and NLP domain.