### PR TITLE
Add Knowledge3D (K3D) under CUDA PTX category

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Further resources:
       - [Extra](#clojure-extra)
   - [Crystal](#crystal)
       - [General-Purpose Machine Learning](#crystal-general-purpose-machine-learning)
+  - [CUDA PTX](#cuda-ptx)
+      - [Neurosymbolic AI](#cuda-ptx-neurosymbolic-ai)
   - [Elixir](#elixir)
       - [General-Purpose Machine Learning](#elixir-general-purpose-machine-learning)
       - [Natural Language Processing](#elixir-natural-language-processing)
@@ -386,6 +388,14 @@ Further resources:
 
 * [machine](https://github.com/mathieulaporte/machine) - Simple machine learning algorithm.
 * [crystal-fann](https://github.com/NeuraLegion/crystal-fann) - FANN (Fast Artificial Neural Network) binding.
+
+<a name="cuda-ptx"></a>
+## CUDA PTX
+
+<a name="cuda-ptx-neurosymbolic-ai"></a>
+#### Neurosymbolic AI
+
+* [Knowledge3D (K3D)](https://github.com/danielcamposramos/Knowledge3D) - Sovereign GPU-native spatial AI architecture with PTX-first cognitive engine (RPN/TRM reasoning), tri-modal fusion (text/visual/audio), and 3D persistent memory ("Houses"). Features sub-100µs inference, procedural knowledge compression (69:1 ratio), and multi-agent swarm architecture. Zero external dependencies for core inference paths.
 
 <a name="elixir"></a>
 ## Elixir


### PR DESCRIPTION
## Description
Added Knowledge3D (K3D) as a new CUDA PTX section, properly categorizing it as a neurosymbolic AI architecture rather than a tool.

## Changes
- Created new **CUDA PTX** category following the language-based organization pattern
- Added K3D under "Neurosymbolic AI" subsection
- Highlights K3D's sovereign GPU-native architecture with PTX-first cognitive engine

## Why CUDA PTX Category?
K3D is not a tool—it's a complete AI architecture built on hand-written PTX kernels with zero external dependencies for core inference. It deserves its own language category alongside C, C++, Python, etc.

## Project Details
- 🧠 PTX-first cognitive engine (RPN/TRM reasoning)
- 🎨 Tri-modal fusion (text/visual/audio)
- 🏠 3D persistent memory architecture
- ⚡ Sub-100µs inference latency
- 📦 69:1 procedural knowledge compression
- 🔒 Zero external dependencies (sovereign stack)

Repository: https://github.com/danielcamposramos/Knowledge3D