### PR TITLE
Add jSciPy to Java General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [FlinkML in Apache Flink](https://ci.apache.org/projects/flink/flink-docs-master/dev/libs/ml/index.html) - Distributed machine learning library in Flink.
 * [H2O](https://github.com/h2oai/h2o-3) - ML engine that supports distributed learning on Hadoop, Spark or your laptop via APIs in R, Python, Scala, REST/JSON.
 * [htm.java](https://github.com/numenta/htm.java) - General Machine Learning library using Numenta’s Cortical Learning Algorithm.
+* [jSciPy](https://github.com/hissain/jscipy) - A Java port of SciPy's signal processing module, offering filters, transformations, and other scientific computing utilities.
 * [liblinear-java](https://github.com/bwaldvogel/liblinear-java) - Java version of liblinear.
 * [Mahout](https://github.com/apache/mahout) - Distributed machine learning.
 * [Meka](http://meka.sourceforge.net/) - An open source implementation of methods for multi-label classification and evaluation (extension to Weka).


### PR DESCRIPTION
Adding `jSciPy`, a comprehensive Java port of SciPy's signal processing module. This library provides essential scientific computing utilities for the Java ecosystem, including filters, transformations, and smoothing algorithms. It fits well within the General-Purpose Machine Learning section as a foundational tool for data processing.