### PR TITLE
Add "The Math Behind Artificial Intelligence" to Linear Algebra section in books.md

### DIFF
--- a/books.md
+++ b/books.md
@@ -148,6 +148,7 @@ The following is a list of free and/or open source books on machine learning, st
 * [Linear Algebra, Theory, and Applications](https://math.byu.edu/~klkuttle/Linearalgebra.pdf)
 * [Convex Optimization](https://web.stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf)
 * [Applied Numerical Computing](https://www.seas.ucla.edu/~vandenbe/ee133a.html)
+* [The Math Behind Artificial Intelligence](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book)
 
 ## Calculus
 


### PR DESCRIPTION
Added comprehensive mathematical foundations resource to the Linear Algebra section in books.md:

- **The Math Behind Artificial Intelligence** by Tiago Monteiro (freeCodeCamp, 2026)
- Free online book covering linear algebra, multivariable calculus, probability & statistics, and optimization theory
- Engineering-focused explanations with visual aids, analogies, and Python code examples
- Bridges pure mathematics and AI/ML applications

Position: Added as the last entry in the Linear Algebra section, after "Applied Numerical Computing".