### PR TITLE
Add GPU Per Hour - GPU cloud price comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1865,6 +1865,7 @@ be
 * [CML](https://github.com/iterative/cml) - A library for doing continuous integration with ML projects. Use GitHub Actions & GitLab CI to train and evaluate models in production like environments and automatically generate visual reports with metrics and graphs in pull/merge requests. Framework & language agnostic.
 * [Pythonizr](https://pythonizr.com) - An online tool to generate boilerplate machine learning code that uses scikit-learn.
 * [Flyte](https://flyte.org/) - Flyte makes it easy to create concurrent, scalable, and maintainable workflows for machine learning and data processing.
+* [GPU Per Hour](https://gpuperhour.com) - Real-time GPU cloud price comparison across 30+ providers.
 * [Chaos Genius](https://github.com/chaos-genius/chaos_genius/) - ML powered analytics engine for outlier/anomaly detection and root cause analysis.
 * [MLEM](https://github.com/iterative/mlem) - Version and deploy your ML models following GitOps principles
 * [DockerDL](https://github.com/matifali/dockerdl) - Ready to use deeplearning docker images.


### PR DESCRIPTION
## Summary
- Added [GPU Per Hour](https://gpuperhour.com) to the Tools > Misc section
- Real-time GPU cloud price comparison across 30+ providers
- Helps ML practitioners find the most cost-effective GPU compute options for training and inference

## Why this belongs here
GPU Per Hour is a valuable resource for machine learning practitioners who need to compare GPU cloud pricing across multiple providers.