### PR TITLE
Add a reference to 'qsmm'

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Further resources:
 * [cONNXr](https://github.com/alrevuelta/cONNXr) - An `ONNX` runtime written in pure C (99) with zero dependencies focused on small embedded devices. Run inference on your machine learning models no matter which framework you train it with. Easy to install and compiles everywhere, even in very old devices.
 * [libonnx](https://github.com/xboot/libonnx) - A lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 * [onnx-c](https://github.com/onnx/onnx-c) - A lightweight C library for ONNX model inference, optimized for performance and portability across platforms.
+* [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 
 <a name="c-computer-vision"></a>
 #### Computer Vision


### PR DESCRIPTION
Add a reference to 'qsmm' (http://qsmm.org), a C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs