### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1881,6 +1881,8 @@ be
 * [Local LLM NPC](https://github.com/code-forge-temple/local-llm-npc) - Godot 4.x asset that enables NPCs to interact with players using local LLMs for structured, offline-first learning conversations in games.
 * [Awesome Hugging Face Models](https://github.com/JehoshuaM/awesome-huggingface-models) - Curated list of top Hugging Face models for NLP, vision, and audio tasks with demos and benchmarks.
 * [PraisonAI](https://github.com/MervinPraison/PraisonAI) - Production-ready Multi-AI Agents framework with self-reflection. Fastest agent instantiation (3.77μs), 100+ LLM support via LiteLLM, MCP integration, agentic workflows (route/parallel/loop/repeat), built-in memory, Python & JS SDKs.
+* [Bread Dataset Viewer](https://github.com/Bread-Technologies/mle_vscode_extension) - A VS Code extension for viewing and exploring large machine learning datasets (CSV, JSON, Parquet, etc.) directly within the editor without VS Code crashing in a clean UI.
+* [Bread WandB Viewer](https://github.com/Bread-Technologies/bread_wandb_viewer_extension) - A VS Code extension to view Weights & Biases experiments, logs, and artifacts within the IDE, eliminating the need to switch to the web UI and keeping data private.
 
 <a name="books"></a>
 ## Books


### PR DESCRIPTION
Added two useful VS Code IDE extensions to **Tools > Misc**

**First extension**: An easy way to view and interact with large datasets (JSON(L)/CSV/arrow) cleanly and in a way that doesn't crash VS Code when the file is too large.

**Second extension**: A way to visualize weights & biases training data (`.wandb`) directly within the IDE. Visualize loss plots and copy generated context for an AI agent to understand training runs without having to open the Web UI. Maximizes privacy keeping everything offline and not requiring switching to the Web UI.