### PR TITLE
Add vLLM to Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ be
 * [Opik](https://github.com/comet-ml/opik): Evaluate, trace, test, and ship LLM applications across your dev and production lifecycles.
 * [pyclugen](https://github.com/clugen/pyclugen) - Multidimensional cluster generation in Python.
 * [mlforgex](https://github.com/dhgefergfefruiwefhjhcduc/ML_Forgex) - Lightweight ML utility for automated training, evaluation, and prediction with CLI and Python API support.
+* [vLLM](https://github.com/vllm-project/vllm) - A high-throughput and memory-efficient inference and serving engine for LLMs.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Added [vLLM](https://github.com/vllm-project/vllm) to the Python General-Purpose Machine Learning section.

vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It has 71K+ GitHub stars and is widely adopted in production for serving models like LLaMA, Mistral, and DeepSeek.

Surprised it wasn't listed yet.