### PR TITLE
Add AI Displacement Tracker dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [ParaMonte](https://github.com/cdslaborg/paramonte) - A general-purpose Fortran library for Bayesian data analysis and visualization via serial/parallel Monte Carlo and MCMC simulations. Documentation can be found [here](https://www.cdslab.org/paramonte/).
 
 <a name="go"></a>
+* [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset tracking 94 AI-attributed workforce displacement events affecting 453K+ workers across 12 countries. CSV/JSON format with source-linked attribution.
+
 ## Go
 
 <a name="go-natural-language-processing"></a>


### PR DESCRIPTION
Adds [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the Python Data Analysis / Data Visualization section.

**What it is:** A structured, source-linked dataset tracking 94 AI-attributed workforce displacement events affecting 453,000+ workers across 12 countries and 11 industry sectors. Available in CSV and JSON formats with a 3-tier attribution system (confirmed, probable, unverified).

**Why it fits this list:** The dataset provides structured data for analyzing the real-world workforce impact of machine learning deployment — useful for data analysis, visualization, and research into ML's economic effects.

Listed in [awesome-datascience](https://github.com/academic/awesome-datascience) (24K stars).