### PR TITLE
Add iNaturalist to Computer Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,7 @@ be
 * [segmentation_models.pytorch](https://github.com/qubvel/segmentation_models.pytorch) - A PyTorch-based toolkit that offers pre-trained segmentation models for computer vision tasks. It simplifies the development of image segmentation applications by providing a collection of popular architecture implementations, such as UNet and PSPNet, along with pre-trained weights, making it easier for researchers and developers to achieve high-quality pixel-level object segmentation in images.
 * [segmentation_models](https://github.com/qubvel/segmentation_models) - A TensorFlow Keras-based toolkit that offers pre-trained segmentation models for computer vision tasks. It simplifies the development of image segmentation applications by providing a collection of popular architecture implementations, such as UNet and PSPNet, along with pre-trained weights, making it easier for researchers and developers to achieve high-quality pixel-level object segmentation in images.
 * [MLX](https://github.com/ml-explore/mlx)- MLX is an array framework for machine learning on Apple silicon, developed by Apple machine learning research.
+* [iNaturalist](https://www.inaturalist.org/pages/computer_vision_demo) - Species identification model trained on 76,000+ taxa from community observations. Transfer learning demo with open dataset.
 
 <a name="python-natural-language-processing"></a>
 #### Natural Language Processing


### PR DESCRIPTION
iNaturalist's computer vision model identifies 76,000+ taxa from photos using transfer learning trained on community-contributed observations. Adds species classification to the Computer Vision section.