### PR TITLE
Add dna-claude-analysis to Python Misc Scripts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ be
 * [decision-weights](https://github.com/CamDavidsonPilon/decision-weights)
 * [Sarah Palin LDA](https://github.com/Wavelets/sarah-palin-lda) - Topic Modelling the Sarah Palin emails.
 * [Diffusion Segmentation](https://github.com/Wavelets/diffusion-segmentation) - A collection of image segmentation algorithms based on diffusion methods.
+* [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) and generating a terminal-style single-page HTML visualization.
 * [Scipy Tutorials](https://github.com/Wavelets/scipy-tutorials) - SciPy tutorials. This is outdated, check out scipy-lecture-notes.
 * [Crab](https://github.com/marcelcaraciolo/crab) - A recommendation engine library for Python.
 * [BayesPy](https://github.com/maxsklar/BayesPy) - Bayesian Inference Tools in Python.


### PR DESCRIPTION
## Description

Adding [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Python → Misc Scripts / iPython Notebooks / Codebases** section.

**dna-claude-analysis** is a personal genome analysis toolkit that:
- Analyzes raw DNA data (23andMe/AncestryDNA format) across 17 categories including health risks, ancestry, pharmacogenomics, nutrition, sports fitness, psychology, cognitive traits, longevity, sleep, immunity, pain sensitivity, detoxification, skin, vision/hearing, physical traits, and carrier status
- Uses Python scripts to parse SNP data and generate structured markdown reports
- Generates a terminal-style single-page HTML visualization with inline CSS/JS (no external dependencies)

## Checklist

- [x] My addition is alphabetically ordered in the appropriate section
- [x] I have added a description for the tool
- [x] The link points to a valid public GitHub repository
- [x] The tool/project is related to machine learning / data analysis