### PR TITLE
Add Deploybase to Tools Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1881,6 +1881,7 @@ be
 * [Local LLM NPC](https://github.com/code-forge-temple/local-llm-npc) - Godot 4.x asset that enables NPCs to interact with players using local LLMs for structured, offline-first learning conversations in games.
 * [Awesome Hugging Face Models](https://github.com/JehoshuaM/awesome-huggingface-models) - Curated list of top Hugging Face models for NLP, vision, and audio tasks with demos and benchmarks.
 * [PraisonAI](https://github.com/MervinPraison/PraisonAI) - Production-ready Multi-AI Agents framework with self-reflection. Fastest agent instantiation (3.77μs), 100+ LLM support via LiteLLM, MCP integration, agentic workflows (route/parallel/loop/repeat), built-in memory, Python & JS SDKs.
+* [Deploybase](https://deploybase.ai/) - Track real-time GPU and LLM pricing across all cloud and inference providers.
 
 <a name="books"></a>
 ## Books


### PR DESCRIPTION
Adding Deploybase, a real-time GPU and LLM pricing aggregator dashboard that tracks pricing across all major cloud and inference providers. Useful for ML practitioners comparing compute costs.