### PR TITLE
Add Rapid-MLX to Python General-Purpose ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,6 +1320,7 @@ be
 * [Opik](https://github.com/comet-ml/opik): Evaluate, trace, test, and ship LLM applications across your dev and production lifecycles.
 * [pyclugen](https://github.com/clugen/pyclugen) - Multidimensional cluster generation in Python.
 * [mlforgex](https://github.com/dhgefergfefruiwefhjhcduc/ML_Forgex) - Lightweight ML utility for automated training, evaluation, and prediction with CLI and Python API support.
+* [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible LLM inference server for Apple Silicon using MLX. 2-4x faster than Ollama with tool calling and prompt caching.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
## Summary
- Adds [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) to the Python > General-Purpose Machine Learning section

Rapid-MLX is an OpenAI-compatible LLM inference server optimized for Apple Silicon using MLX. It provides 2-4x faster inference than Ollama, with full tool calling support, reasoning separation, and prompt caching. Apache-2.0 licensed.