### PR TITLE
Add podcast to Podcasts section

### DIFF
--- a/blogs.md
+++ b/blogs.md
@@ -21,6 +21,7 @@ Podcasts
 * [DataTalks.Club](https://anchor.fm/datatalksclub)
 * [Super Data Science Podcast with Jon Krohn](https://www.youtube.com/@SuperDataScienceWithJonKrohn)
 * [AI Stories Podcast](https://www.youtube.com/@aistoriespodcast)
+* [Chain of Thought](https://chainofthought.show/)
 
 Newsletters
 -----------


### PR DESCRIPTION
Adds Chain of Thought to the Podcasts section in blogs.md. Weekly AI podcast covering inference infrastructure, developer tools, and strategy.

https://chainofthought.show/