### PR TITLE
Remove dead link to nebuly-ai/optimate speedster app

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Further resources:
 #### General-Purpose Machine Learning
 
 * * [Agentic Context Engine](https://github.com/kayba-ai/agentic-context-engine) -In-context learning framework that allows agents to learn from execution feedback.
-* [Speedster](https://github.com/nebuly-ai/nebullvm/tree/main/apps/accelerate/speedster) -Automatically apply SOTA optimization techniques to achieve the maximum inference speed-up on your hardware. [DEEP LEARNING]
+
 * [BanditLib](https://github.com/jkomiyama/banditlib) - A simple Multi-armed Bandit library. **[Deprecated]**
 * [Caffe](https://github.com/BVLC/caffe) - A deep learning framework developed with cleanliness, readability, and speed in mind. [DEEP LEARNING]
 * [CatBoost](https://github.com/catboost/catboost) - General purpose gradient boosting on decision trees library with categorical features support out of the box. It is easy to install, contains fast inference implementation and supports CPU and GPU (even multi-GPU) computation.


### PR DESCRIPTION
Hi!
I was checking some links and noticed that the link to the speedster tool (https://github.com/nebuly-ai/optimate/tree/main/apps/accelerate/speedster) is returning a 404 Not Found error.

It looks like the folder was moved or removed from the optimate repository. I have removed the dead link to keep the documentation accurate.

Thanks for maintaining this awesome list!
(Note: I manually verified this 404 error in my browser before submitting this PR).