### PR TITLE
Add Legend of Elya N64 — transformer on Nintendo 64 hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Further resources:
 * [libonnx](https://github.com/xboot/libonnx) - A lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 * [onnx-c](https://github.com/onnx/onnx-c) - A lightweight C library for ONNX model inference, optimized for performance and portability across platforms.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
+* [Legend of Elya N64](https://github.com/Scottcjn/legend-of-elya-n64) - An 819K-parameter transformer running on Nintendo 64 MIPS III hardware (93.75 MHz VR4300). Byte-level inference at 60 tok/s inside a Zelda-style game using the libdragon SDK.
 
 <a name="c-computer-vision"></a>
 #### Computer Vision


### PR DESCRIPTION
Adds [Legend of Elya N64](https://github.com/Scottcjn/legend-of-elya-n64) to the C > General-Purpose Machine Learning section.

**What it is**: An 819K-parameter transformer model running inference inside a Nintendo 64 game on the MIPS III VR4300 CPU at 93.75 MHz. Built with the [libdragon](https://github.com/DragonMinded/libdragon) SDK.

**Why it fits**: It's a working neural network inference engine written in C, targeting the most constrained hardware imaginable — 4 MB of RAM on a 1996 game console. The RSP vector coprocessor is used for SIMD matrix operations.

- 60 tok/s byte-level inference
- Zelda-style game with AI-driven NPCs
- Already merged into [awesome-n64-development](https://github.com/command-tab/awesome-n64-development)
- From the same lab behind a [CVPR 2026 workshop paper](https://github.com/Scottcjn/grail-v-emotional-grounding) and [merged OpenSSL contributions](https://github.com/openssl/openssl/pull/30437)