### PR TITLE
Add AI Weekly to Newsletters section

### DIFF
--- a/blogs.md
+++ b/blogs.md
@@ -24,6 +24,7 @@ Podcasts
 
 Newsletters
 -----------
+* [AI Weekly](https://aiweekly.co). Curated AI intelligence briefing from industry leaders covering models, funding, policy, and applications. 3x/week since 2017, 40K+ subscribers.
 
 * [AI Digest](https://aidigest.net/). A weekly newsletter to keep up to date with AI, machine learning, and data science. [Archive](https://aidigest.net/digests).
 * [DataTalks.Club](https://datatalks.club). A weekly newsletter about data-related things. [Archive](https://us19.campaign-archive.com/home/?u=0d7822ab98152f5afc118c176&id=97178021aa)


### PR DESCRIPTION
Adding [AI Weekly](https://aiweekly.co), one of the longest-running AI newsletters — curated intelligence briefings from industry leaders covering models, funding, policy, and applications. 3x/week since 2017 with 40K+ subscribers.

AI Weekly has been featured on Machine Learning Mastery, Python Engineer, and multiple 'best AI newsletters' roundups.