### PR TITLE
Add veroq - LLM output verification library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ be
 * [Transformers](https://github.com/huggingface/transformers) - A deep learning library containing thousands of pre-trained models on different tasks. The goto place for anything related to Large Language Models.
 * [TextCL](https://github.com/alinapetukhova/textcl) - Text preprocessing package for use in NLP tasks.
 * [VeritasGraph](https://github.com/bibinprathap/VeritasGraph) - Enterprise-Grade Graph RAG for Secure, On-Premise AI with Verifiable Attribution.
+* [veroq](https://github.com/veroq-ai/shield) - Verify any LLM output with one function call. Extracts claims, fact-checks against live evidence (web search, financial data, public records), and returns trust scores with corrections.
 
 <a name="python-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning


### PR DESCRIPTION
## What is VeroQ?

[VeroQ Shield](https://github.com/veroq-ai/shield) verifies any LLM output in one function call:

```python
from veroq import shield
result = shield("NVIDIA reported $22B in Q4 revenue")
print(result.trust_score)   # 0.73
print(result.corrections)   # [{claim, correction}]
```

- Extracts claims from any LLM text
- Verifies each against live evidence (web search, financial data, public records)
- Returns trust score, corrections, and permanent verification receipts
- Python (`pip install veroq`) and TypeScript (`npm install @veroq/sdk`)
- 2,000+ weekly installs across npm and PyPI

## Placement

Added under **Python > Natural Language Processing** in alphabetical order, as VeroQ's core functionality is claim extraction and natural language verification.
