### PR TITLE
Add LongTrainer to NLP frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ be
 * [NALP](https://github.com/gugarosa/nalp) - A Natural Adversarial Language Processing framework built over Tensorflow.
 * [DL Translate](https://github.com/xhlulu/dl-translate) - A deep learning-based translation library between 50 languages, built with `transformers`.
 * [Haystack](https://github.com/deepset-ai/haystack) - A framework for building industrial-strength applications with Transformer models and LLMs.
+* [LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer) - A production-ready agentic RAG framework leveraging LangChain and LangGraph for scalable LLM apps.
 * [CometLLM](https://github.com/comet-ml/comet-llm) - Track, log, visualize and evaluate your LLM prompts and prompt chains.
 * [NobodyWho](https://github.com/nobodywho-ooo/nobodywho) - The simplest way to run an LLM locally. Supports tool calling and grammar constrained sampling.
 * [Transformers](https://github.com/huggingface/transformers) - A deep learning library containing thousands of pre-trained models on different tasks. The goto place for anything related to Large Language Models.


### PR DESCRIPTION
Hi there! 👋

I would like to propose adding **[LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer)** to this awesome list. 

### What is LongTrainer?
LongTrainer is a production-ready framework built on top of LangChain. It allows developers to turn their documents into intelligent, multi-tenant chatbots with just a few lines of code. 

### Why is it a good fit here?
It abstracts away the complexities of manually wiring together chains, memory, tools, and retrievers by offering batteries-included features for production:
- **Multi-bot architecture:** Built-in multi-tenant isolation for managing separate bots effortlessly.
- **Persistent Memory:** Ready-to-use MongoDB-backed, encrypted chat history.
- **Agentic Capabilities:** Supports both standard RAG pipelines and dynamic LangGraph agent tool-calling (web search, custom functions).
- **Extensive Document & Vision Support:** Natively parses PDFs, databases, URLs, and multi-modal images without friction.
- **Streaming:** First-class support for sync and async streaming out of the box.

I believe this will be an extremely valuable, time-saving resource for developers in this community looking to spin up robust GenAI/RAG applications in production quickly.

Thank you for your time and for maintaining this awesome list! Let me know if you need me to adjust the formatting to better fit the repository guidelines. 
