### PR TITLE
Add Orallexa — AI trading system with 9 ML models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,7 @@ be
 * [cleanlab](https://github.com/cleanlab/cleanlab): The standard data-centric AI package for data quality and machine learning with messy, real-world data and labels.
 * [AutoGluon](https://github.com/awslabs/autogluon): AutoML for Image, Text, Tabular, Time-Series, and MultiModal Data.
 * [PyBroker](https://github.com/edtechre/pybroker) - Algorithmic Trading with Machine Learning.
+* [Orallexa](https://github.com/alex-jb/orallexa-ai-trading-agent) - AI trading system with 9 ML models (RF, XGBoost, EMAformer, DDPM, PPO RL, GNN) + adversarial debate. Walk-forward validated, 698 tests.
 * [Frouros](https://github.com/IFCA/frouros): Frouros is an open source Python library for drift detection in machine learning systems.
 * [CometML](https://github.com/comet-ml/comet-examples): The best-in-class MLOps platform with experiment tracking, model production monitoring, a model registry, and data lineage from training straight through to production.
 * [ClearML](https://github.com/clearml/clearml) -  Auto-Magical CI/CD to streamline your AI workload. Experiment Management, Data Management, Pipeline, Orchestration, Scheduling & Serving in one MLOps/LLMOps solution. 


### PR DESCRIPTION
Adds Orallexa to the Python > General-Purpose Machine Learning section, next to PyBroker.

**Entry:**
```
* [Orallexa](https://github.com/alex-jb/orallexa-ai-trading-agent) - AI trading system with 9 ML models (RF, XGBoost, EMAformer, DDPM, PPO RL, GNN) + adversarial debate. Walk-forward validated, 698 tests.
```

**Highlights:**
- 9 ML models scored and ranked by Sharpe ratio
- Adversarial Bull/Bear/Judge debate via Claude AI
- Walk-forward evaluation with statistical significance tests
- MIT licensed, v1.0.0, 698 automated tests
- Live demo: https://orallexa-ui.vercel.app