### PR TITLE
Add HeyTensor to Python Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1527,8 +1527,9 @@ be
 * [EspNet](https://github.com/espnet/espnet) - ESPnet is an end-to-end speech processing toolkit for tasks like speech recognition, translation, and enhancement, using PyTorch and Kaldi-style data processing.
 
 <a name="python-development tools"></a>
-#### Development Tools 
+#### Development Tools
 * [CodeFlash.AI](https://www.codeflash.ai/) – CodeFlash.AI – Ship Blazing-Fast Python Code, Every Time.
+* [HeyTensor](https://heytensor.com) – Browser-based PyTorch tensor shape calculator. Computes shapes through Conv, Linear, LSTM, and Transformer layers without running code. Includes architecture presets (LeNet, ResNet block, Transformer encoder) and a "paste error" mode for parsing PyTorch RuntimeErrors.
 
 <a name="ruby"></a>
 ## Ruby


### PR DESCRIPTION
Adds [HeyTensor](https://heytensor.com) to the `Python / Development Tools` section, alongside CodeFlash.AI.

## What it is
HeyTensor is a free, browser-based PyTorch tensor shape calculator. It solves a common pain point when building neural networks: figuring out the output shape of a Conv/Linear/LSTM/Transformer layer without having to write and run test code.

## Why it fits this list
This list already has a `Python / Development Tools` subsection for Python ML developer utilities. HeyTensor is a natural fit there:
- 14 PyTorch layer types supported (Conv1d/2d/3d, Linear, LSTM, GRU, MultiheadAttention, LayerNorm, etc.)
- Architecture presets for LeNet, ResNet blocks, and Transformer encoders
- A "paste error" mode that parses PyTorch `RuntimeError` messages and explains the shape mismatch
- 100% client-side, no signup, no backend

## Notes
- The tool is publicly accessible and working right now.
- Disclosure: I have a connection to the tool. Happy to adjust wording or placement if preferred.