### PR TITLE
Add BenchGecko - AI model benchmark comparison API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1876,6 +1876,7 @@ be
 * [DockerDL](https://github.com/matifali/dockerdl) - Ready to use deeplearning docker images.
 * [Aqueduct](https://github.com/aqueducthq/aqueduct) - Aqueduct enables you to easily define, run, and manage AI & ML tasks on any cloud infrastructure.
 * [Ambrosia](https://github.com/reactorsh/ambrosia) - Ambrosia helps you clean up your LLM datasets using _other_ LLMs.
+* [BenchGecko](https://benchgecko.ai) - Free API for AI model benchmarks, pricing, and comparisons. Tracks 414+ models across 40 benchmarks including MMLU, HumanEval, and GSM8K.
 * [Fiddler AI](https://www.fiddler.ai) - The all-in-one AI Observability and Security platform for responsible AI. It provides monitoring, analytics, and centralized controls to operationalize ML, GenAI, and LLM applications with trust. Fiddler helps enterprises scale LLM and ML deployments to deliver high performance AI, reduce costs, and be responsible in governance.
 * [Maxim AI](https://getmaxim.ai) - The agent simulation, evaluation, and observability platform helping product teams ship their AI applications with the quality and speed needed for real-world use.
 * [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source LLM evaluation and red teaming framework. Test prompts, models, agents, and RAG pipelines. Run adversarial attacks (jailbreaks, prompt injection) and integrate security testing into CI/CD.


### PR DESCRIPTION
Added BenchGecko to the Tools / Misc section.

BenchGecko is a free API and website for comparing AI model benchmarks, pricing, and capabilities. It tracks 414+ models across 55 providers and 40 benchmarks (MMLU, HumanEval, GSM8K, etc.).

- Website: https://benchgecko.ai
- Free API: https://benchgecko.ai/api/v1
- No API key required for basic use