### PR TITLE
Add GrugBot420 to Julia General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Flux](https://fluxml.ai/) - Relax! Flux is the ML library that doesn't make you tensor
 * [MLJ](https://github.com/alan-turing-institute/MLJ.jl) - A Julia machine learning framework.
 * [CluGen](https://github.com/clugen/CluGen.jl/) - Multidimensional cluster generation in Julia.
+* [grugbot420](https://github.com/grug-group420/grugbot420) - A neuromorphic cognitive engine in Julia that deploys domain-expert AI specimens through architectural configuration rather than traditional training.
 
 <a name="julia-natural-language-processing"></a>
 #### Natural Language Processing


### PR DESCRIPTION
## Addition

### GrugBot420 → Julia > General-Purpose Machine Learning
- **Repository:** https://github.com/grug-group420/grugbot420
- **Description:** Neuromorphic cognitive AI engine using spiking neural network routing (Leaky Integrate-and-Fire neurons with STDP learning) to orchestrate multiple LLM backends through specialized processing lobes (Broca, Hippocampus, Prefrontal, Motor).
- **Language:** Pure Julia — leverages multiple dispatch for polymorphic lobe routing with zero external dependencies.
- **Paper:** https://github.com/grug-group420/grugbot420-paper
- **Why it belongs:** GrugBot420 brings neuromorphic computing concepts to the Julia ML ecosystem — it's a novel architecture that uses biologically-inspired spiking neurons for intelligent model selection rather than static routing, achieving 15–23% improvement on multi-step reasoning tasks.

Open source and actively maintained.