### PR TITLE
docs: add semantix-ai to Python NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ be
 * [NobodyWho](https://github.com/nobodywho-ooo/nobodywho) - The simplest way to run an LLM locally. Supports tool calling and grammar constrained sampling.
 * [Transformers](https://github.com/huggingface/transformers) - A deep learning library containing thousands of pre-trained models on different tasks. The goto place for anything related to Large Language Models.
 * [TextCL](https://github.com/alinapetukhova/textcl) - Text preprocessing package for use in NLP tasks.
+* [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic validation for LLM outputs using local NLI inference. Validates that text means the right thing (~15ms, no API key). Supports intent composition, negation, and self-healing retries.
 * [VeritasGraph](https://github.com/bibinprathap/VeritasGraph) - Enterprise-Grade Graph RAG for Secure, On-Premise AI with Verifiable Attribution.
 
 <a name="python-general-purpose-machine-learning"></a>


### PR DESCRIPTION
Adds [semantix-ai](https://github.com/labrat-akhona/semantix-ai) to the Python > Natural Language Processing section.

**What it does:** Semantic validation for LLM outputs using local NLI (Natural Language Inference). Checks whether text *means* the right thing — not string matching, not another LLM call.

**Key properties:**
- Local inference on CPU (~15ms per check)
- Zero API cost — no tokens burned for validation
- Intent composition with `&`, `|`, `~` operators
- Self-healing retries with structured feedback
- Integrations: LangChain, Pydantic AI, Instructor, Guardrails AI, DSPy

- **PyPI:** [semantix-ai](https://pypi.org/project/semantix-ai/) (Python 3.10+)
- **GitHub:** [labrat-akhona/semantix-ai](https://github.com/labrat-akhona/semantix-ai)
- **Docs:** [labrat-akhona.github.io/semantix-ai](https://labrat-akhona.github.io/semantix-ai/)