### PR TITLE
Add 8bitconcepts to Blogs section

### DIFF
--- a/blogs.md
+++ b/blogs.md
@@ -5,6 +5,7 @@ Blogs/Podcasts
 * [LightTag's Labeled Data Blog](https://lighttag.io/blog)
 * [Freecodecamp articles](https://www.freecodecamp.org/news/tag/machine-learning/)
 * [Fennel Blog](https://fennel.ai/blog/)
+* [8bitconcepts](https://8bitconcepts.com/) - AI industry research and analysis covering pricing, enterprise adoption, and evaluation frameworks
 
 Podcasts
 --------


### PR DESCRIPTION
Adds [8bitconcepts](https://8bitconcepts.com/) to the Blogs/Podcasts list in blogs.md.

8bitconcepts publishes AI industry research papers covering topics like AI pricing models, enterprise adoption patterns, and evaluation frameworks. Currently has 11 published papers.

Follows the existing `* [Name](URL) - Description` format.