### PR TITLE
Add space-ml-sim (orbital satellite AI radiation simulation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,7 @@ be
 * [Opik](https://github.com/comet-ml/opik): Evaluate, trace, test, and ship LLM applications across your dev and production lifecycles.
 * [pyclugen](https://github.com/clugen/pyclugen) - Multidimensional cluster generation in Python.
 * [mlforgex](https://github.com/dhgefergfefruiwefhjhcduc/ML_Forgex) - Lightweight ML utility for automated training, evaluation, and prediction with CLI and Python API support.
+* [space-ml-sim](https://github.com/orbital-sim-lab/space-ml-sim) - Simulate AI inference on orbital satellite constellations under space radiation. PyTorch/ONNX fault injection, Triple Modular Redundancy, distributed inference across inter-satellite links, link budget and ECSS/MIL-STD report generation, and 7 space-hardened chip profiles.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Adds [space-ml-sim](https://github.com/orbital-sim-lab/space-ml-sim) to **Python → General-Purpose Machine Learning**.

**What it is:** an open-source (AGPL-3.0) framework for simulating AI inference on orbital satellite constellations under realistic space radiation.

**Features:**
- PyTorch / ONNX bit-flip fault injection driven by radiation-derived Poisson rates
- Triple Modular Redundancy (full + selective) and checkpoint rollback
- Walker-Delta / sun-sync constellation generation, SGP4 TLE propagation, J2 perturbations
- Distributed inference across inter-satellite links, ground-station link budget
- ECSS / MIL-STD mission report generation
- 7 built-in chip profiles (TERAFAB D3, Trillium TPU v6e, RAD5500, Versal AI Core, Jetson Orin, Zynq, NOEL-V RISC-V)
- Validated against published SEU measurements (ISS, sun-sync EO, high-LEO) and SPENVIS reference data

**Stats:** 497 tests, 80%+ coverage, CI + security scans on every PR, on PyPI.

Project fills a gap in the existing list — there is no other entry for space / orbital ML or radiation-tolerant inference simulation.