### PR TITLE
Add comprisk under Python > Survival Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ be
 #### Python Survival Analysis
 * [lifelines](https://github.com/CamDavidsonPilon/lifelines) - lifelines is a complete survival analysis library, written in pure Python
 * [Scikit-Survival](https://github.com/sebp/scikit-survival) - scikit-survival is a Python module for survival analysis built on top of scikit-learn. It allows doing survival analysis while utilizing the power of scikit-learn, e.g., for pre-processing or doing cross-validation.
+* [crforest](https://github.com/sunnyadn/crforest) - Competing-risks Random Survival Forest in Python with Aalen–Johansen CIF, cause-specific C-indices, and OOB permutation VIMP. 10–22× faster than R's randomForestSRC on real EHR data (CHF + SEER); scales to n = 10⁶ on a consumer desktop in ~1 min.
 
 <a name="python-federated-learning"></a>
 #### Federated Learning

--- a/README.md
+++ b/README.md
@@ -1483,7 +1483,7 @@ be
 #### Python Survival Analysis
 * [lifelines](https://github.com/CamDavidsonPilon/lifelines) - lifelines is a complete survival analysis library, written in pure Python
 * [Scikit-Survival](https://github.com/sebp/scikit-survival) - scikit-survival is a Python module for survival analysis built on top of scikit-learn. It allows doing survival analysis while utilizing the power of scikit-learn, e.g., for pre-processing or doing cross-validation.
-* [crforest](https://github.com/sunnyadn/crforest) - Competing-risks Random Survival Forest in Python with Aalen–Johansen CIF, cause-specific C-indices, and OOB permutation VIMP. 10–22× faster than R's randomForestSRC on real EHR data (CHF + SEER); scales to n = 10⁶ on a consumer desktop in ~1 min.
+* [comprisk](https://github.com/sunnyadn/comprisk) - Python toolkit for competing risks. Random Survival Forest today (10–22× faster than R's randomForestSRC on real EHR; scales to n=10⁶ in ~1 min); Fine-Gray regression + cumulative incidence + Gray's K-sample + cause-specific Cox in v0.4.
 
 <a name="python-federated-learning"></a>
 #### Federated Learning

--- a/README.md
+++ b/README.md
@@ -1483,7 +1483,7 @@ be
 #### Python Survival Analysis
 * [lifelines](https://github.com/CamDavidsonPilon/lifelines) - lifelines is a complete survival analysis library, written in pure Python
 * [Scikit-Survival](https://github.com/sebp/scikit-survival) - scikit-survival is a Python module for survival analysis built on top of scikit-learn. It allows doing survival analysis while utilizing the power of scikit-learn, e.g., for pre-processing or doing cross-validation.
-* [comprisk](https://github.com/sunnyadn/comprisk) - Python toolkit for competing risks. Random Survival Forest today (10–22× faster than R's randomForestSRC on real EHR; scales to n=10⁶ in ~1 min); Fine-Gray regression + cumulative incidence + Gray's K-sample + cause-specific Cox in v0.4.
+* [comprisk](https://github.com/sunnyadn/comprisk) - Python toolkit for competing risks. Random Survival Forest with Aalen–Johansen CIF, cause-specific C-indices, and OOB permutation VIMP. 10–22× faster than R's randomForestSRC on real EHR data (CHF + SEER); scales to n=10⁶ in ~1 min.
 
 <a name="python-federated-learning"></a>
 #### Federated Learning


### PR DESCRIPTION
Adds [comprisk](https://github.com/sunnyadn/comprisk) under **Python > Survival Analysis**. (Renamed from `crforest` on 2026-05-04; the original PR title and first commit reference the pre-rename name.)

comprisk is a Python toolkit for competing risks — fills a documented gap since scikit-survival's `RandomSurvivalForest` is single-event only. Random Survival Forest with Aalen–Johansen CIF, cause-specific Harrell/Uno-IPCW C-indices, OOB Breiman permutation VIMP, and a bit-identical reproducibility mode against R's `randomForestSRC`. 10–22× faster than randomForestSRC on real EHR data (CHF + SEER cohorts); scales to n=10⁶ in ~1 min.

The `comprisk` name was chosen over `crforest` because the package's scope is competing risks generally; the forest is one method.

- Repo: https://github.com/sunnyadn/comprisk
- PyPI: https://pypi.org/project/comprisk/
- License: Apache-2.0
- DOI: 10.5281/zenodo.19876282