### PR TITLE
Add Learn AI to courses.md

### DIFF
--- a/courses.md
+++ b/courses.md
@@ -4,6 +4,7 @@ The following is a list of free or paid online courses on machine learning, stat
 
 * [System Designer - ML Systems](https://systemdesigner.net/ml-systems) - Interactive learning platform for ML systems and MLOps with 28 lessons on training pipelines, model serving, feature stores, and monitoring. Includes AI tutor, whiteboards, quizzes, and hands-on projects - free
 * [System Designer - GenAI](https://systemdesigner.net/genai) - Interactive learning platform for GenAI and LLMs with 32 lessons on RAG systems, vector databases, agentic AI, and deployment. Includes AI tutor, whiteboards, quizzes, and projects - free
+* [Learn AI by Rajul Babel](https://rajulbabel.github.io/learn-ai/) - Free, visual, interactive guide to AI end-to-end. Covers neural network internals, transformers, attention, RAG, vector databases (HNSW, IVF, PQ, FAISS, pgvector, Qdrant, Pinecone), and agent frameworks. Real formulas, real diagrams, click-through learning - no signup.
 * [Artificial Intelligence (Columbia University)](https://www.edx.org/course/artificial-intelligence-ai-columbiax-csmm-101x-0) - free
 * [Machine Learning (Columbia University)](https://www.edx.org/course/machine-learning-columbiax-csmm-102x-0) - free
 * [Machine Learning (Stanford University)](https://www.coursera.org/learn/machine-learning) - free


### PR DESCRIPTION
Adds [Learn AI by Rajul Babel](https://rajulbabel.github.io/learn-ai/) to the Machine-Learning / Data Mining section of `courses.md`.

**About the resource:**
- Free, no signup, fully open in the browser.
- Visual, interactive, end-to-end guide to AI: neural network internals, transformers, attention (Q/K/V, multi-head), RAG, vector databases (HNSW, IVF, PQ, FAISS, pgvector, Qdrant, Pinecone, Weaviate, Milvus, Chroma), and agent frameworks.
- Built around progressive sub-step reveals - each click adds one concrete idea, with real formulas, real numbers, and real diagrams (no watered-down explanations).
- MIT-licensed source on GitHub: https://github.com/rajulbabel/learn-ai

Placed alongside the existing "System Designer - GenAI" entry, which is the closest topical match (interactive AI/ML learning platform).

Thanks for maintaining this list!