### PR TITLE
Add Digital Mind News to Blogs/Podcasts

### DIFF
--- a/blogs.md
+++ b/blogs.md
@@ -5,6 +5,7 @@ Blogs/Podcasts
 * [LightTag's Labeled Data Blog](https://lighttag.io/blog)
 * [Freecodecamp articles](https://www.freecodecamp.org/news/tag/machine-learning/)
 * [Fennel Blog](https://fennel.ai/blog/)
+* [Digital Mind News](https://digitalmindnews.com/). Daily AI news, research, and industry analysis aggregated from 30+ sources. [RSS](https://digitalmindnews.com/feed/).
 
 Podcasts
 --------


### PR DESCRIPTION
Adding **Digital Mind News** to the Blogs/Podcasts section in `blogs.md`.

- **Site:** https://digitalmindnews.com
- **RSS:** https://digitalmindnews.com/feed/
- **Description:** Daily AI news, research, and industry analysis aggregated from 30+ sources.
- **Active:** Yes — verified live RSS as of May 5, 2026.

Fits the existing pattern of news aggregators in this section (Hacker News for Data Science, Freecodecamp articles).