### PR TITLE
Add Educational Tools section to README w/ nn-visual entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Further resources:
 
 ### [Tools](#tools-1)
 
+- [Educational Tools](#tools-educational-tools)
 - [Neural Networks](#tools-neural-networks)
 - [Misc](#tools-misc)
 
@@ -1843,6 +1844,10 @@ be
 
 <a name="tools"></a>
 ## Tools
+
+<a name="tools-educational-tools"></a>
+#### Educational Tools
+* [NN Visual](https://nn-visual.com) - Interactive visualizations explaining neural networks, backpropagation, attention mechanisms, and transformers.
 
 <a name="tools-neural-networks"></a>
 #### Neural Networks


### PR DESCRIPTION
Added a new section for educational tools with a link to NN Visual. I wondered if some of the other entries in MISC could also fit into this category but I didn't want to take the authority to move them.