### PR TITLE
Add Dakera to Rust — self-hosted agent memory server with MCP and HNSW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1618,6 +1618,7 @@ be
 * [huggingface/tokenizers](https://github.com/huggingface/tokenizers) - Fast State-of-the-Art Tokenizers optimized for Research and Production
 * [rust-bert](https://github.com/guillaume-be/rust-bert) - Rust native ready-to-use NLP pipelines and transformer-based models (BERT, DistilBERT, GPT2,...)
 * [shimmy](https://github.com/Michael-A-Kuykendall/shimmy) - Python-free Rust inference server for NLP models with OpenAI API compatibility and hot model swapping.
+* [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with HNSW vector indexing and RocksDB persistence. MCP-native protocol for AI agent workflows.
 
 <a name="r"></a>
 ## R


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Rust > Natural Language Processing** section.

## Why it fits

Dakera is written in Rust and implements a production-ready agent memory server combining HNSW approximate nearest neighbor indexing with BM25 full-text search. It is MCP-native (Model Context Protocol), making it directly usable with any AI agent framework. Data is persisted to RocksDB with no external service dependencies.

- Pure Rust implementation
- HNSW vector indexing for semantic similarity search
- BM25 full-text search for keyword retrieval
- Hybrid search combining both modalities
- RocksDB-backed persistence
- MCP protocol for agent integration

## Entry added

In `## Rust > #### Natural Language Processing`:

```
* [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with HNSW vector indexing and RocksDB persistence. MCP-native protocol for AI agent workflows.
```