### PR TITLE
Add Meta's Segment Anything Model (SAM) to Python Computer Vision section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,7 @@ be
 * [segmentation_models.pytorch](https://github.com/qubvel/segmentation_models.pytorch) - A PyTorch-based toolkit that offers pre-trained segmentation models for computer vision tasks. It simplifies the development of image segmentation applications by providing a collection of popular architecture implementations, such as UNet and PSPNet, along with pre-trained weights, making it easier for researchers and developers to achieve high-quality pixel-level object segmentation in images.
 * [segmentation_models](https://github.com/qubvel/segmentation_models) - A TensorFlow Keras-based toolkit that offers pre-trained segmentation models for computer vision tasks. It simplifies the development of image segmentation applications by providing a collection of popular architecture implementations, such as UNet and PSPNet, along with pre-trained weights, making it easier for researchers and developers to achieve high-quality pixel-level object segmentation in images.
 * [MLX](https://github.com/ml-explore/mlx)- MLX is an array framework for machine learning on Apple silicon, developed by Apple machine learning research.
+* [segment-anything](https://github.com/facebookresearch/segment-anything) - Meta AI's Segment Anything Model (SAM): a promptable segmentation system that can segment any object in any image with a single click, box, or text prompt.
 
 <a name="python-natural-language-processing"></a>
 #### Natural Language Processing


### PR DESCRIPTION
## Description

This PR adds **[Segment Anything Model (SAM)](https://github.com/facebookresearch/segment-anything)** by Meta AI to the Python > Computer Vision section.

## Why this resource is valuable

SAM is one of the most significant computer vision contributions of recent years:

- **Universal segmentation**: Can segment any object in any image with zero-shot generalization, requiring no task-specific training
- **Promptable**: Accepts point, box, or mask prompts to identify objects
- **State-of-the-art**: Trained on 11 million images and 1 billion masks (SA-1B dataset)
- **Widely adopted**: Used across research and production CV pipelines
- **Python-native**: Full Python API with PyTorch backend

The repo has 47k+ GitHub stars and is actively maintained by Meta AI Research. It fills a clear gap in this list alongside other segmentation tools like `segmentation_models.pytorch`.