### PR TITLE
Add AI Models Catalog to Tools/Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1928,6 +1928,7 @@ be
 * [Pollinations.AI](https://pollinations.ai) - Free, no-signup APIs for text, image, and audio generation with no API keys required. Offers OpenAI-compatible interfaces and React hooks for easy integration.
 * [Model Zoo](https://modelzoo.co/) - Discover open source deep learning code and pretrained models.
 
+* [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured database of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Machine-readable YAML with TypeScript types and Zod validation.
 ## Credits
 
 * Some of the python libraries were cut-and-pasted from [vinta](https://github.com/vinta/awesome-python)


### PR DESCRIPTION
## Description

Adds the AI Models Catalog to the Tools/Misc section — a structured, open-source database of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities.

## Why This Is Useful for ML Practitioners

- **Model comparison**: Compare pricing, context windows, and capabilities across 95 providers
- **Price calculator**: Calculate monthly costs based on your token usage
- **Interactive catalog**: https://i-need-token.github.io/ai-models/
- **First-party data**: All data sourced from provider APIs
- **npm package**: `npm install ai-models`
- **Machine-readable YAML**: TypeScript types + Zod validation for programmatic access

## Links

- GitHub: https://github.com/i-need-token/ai-models
- Interactive Catalog: https://i-need-token.github.io/ai-models/
- LLM Pricing Comparison: https://i-need-token.github.io/ai-models/llm-pricing.html

## Checklist

- [x] The entry follows the existing format of the list
- [x] The entry is relevant to machine learning practitioners
- [x] The description is concise and follows the style of other entries