### PR TITLE
Add ONNX2Anything – browser-based ONNX model converter (WASM + Pyodide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,8 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [MLPleaseHelp](https://github.com/jgreenemi/MLPleaseHelp) - MLPleaseHelp is a simple ML resource search engine. You can use this search engine right now at [https://jgreenemi.github.io/MLPleaseHelp/](https://jgreenemi.github.io/MLPleaseHelp/), provided via GitHub Pages.
 * [Pipcook](https://github.com/alibaba/pipcook) - A JavaScript application framework for machine learning and its engineering.
 
+* [ONNX2Anything](https://github.com/UnstoppableCurry/onnx2anything) - Convert ONNX models to edge inference formats (NCNN, MNN, TNN, Tengine, PaddleLite) entirely in the browser using WebAssembly and Pyodide. No install, no server, your model never leaves your machine.
+
 <a name="javascript-demos-and-scripts"></a>
 #### Demos and Scripts
 * [The Bot](https://github.com/sta-ger/TheBot) - Example of how the neural network learns to predict the angle between two points created with [Synaptic](https://github.com/cazala/synaptic).


### PR DESCRIPTION
## ONNX2Anything

**[ONNX2Anything](https://github.com/UnstoppableCurry/onnx2anything)** is a 100% browser-based tool to convert ONNX models to edge inference formats.

**Supported output formats:** NCNN, MNN, TNN, Tengine, PaddleLite

**Why it belongs here:**
- JavaScript/TypeScript (React + Vite) frontend
- Each converter compiled to **WebAssembly** via Emscripten
- Python tooling (onnxsim) via **Pyodide** running in browser
- Zero server — runs entirely client-side
- Open source, MIT license

**Added to:** JavaScript → Misc

Live: https://onnx2anything.com  
Repo: https://github.com/UnstoppableCurry/onnx2anything