### PR TITLE
Add FunASR to Python Speech Recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,6 +1546,7 @@ be
 <a name="python-speech-recognition"></a>
 #### Speech Recognition
 * [EspNet](https://github.com/espnet/espnet) - ESPnet is an end-to-end speech processing toolkit for tasks like speech recognition, translation, and enhancement, using PyTorch and Kaldi-style data processing.
+* [FunASR](https://github.com/modelscope/FunASR) - An industrial-grade speech recognition toolkit supporting multilingual ASR, VAD, punctuation restoration, speaker diarization, and emotion recognition.
 
 <a name="python-development tools"></a>
 #### Development Tools 

--- a/README.md
+++ b/README.md
@@ -1577,6 +1577,7 @@ be
 #### Speech Recognition
 * [EspNet](https://github.com/espnet/espnet) - ESPnet is an end-to-end speech processing toolkit for tasks like speech recognition, translation, and enhancement, using PyTorch and Kaldi-style data processing.
 * [VoxRT](https://github.com/VoxRT/voxrt-asr-linux) - On-device streaming speech recognition toolkit with Python bindings. Based on NVIDIA NeMo FastConformer (80 ms cache-aware lookahead). Ships companion VAD (Silero), wake-word, and 14-command keyword spotting via same runtime.
+* [FunASR](https://github.com/modelscope/FunASR) - An industrial-grade speech recognition toolkit supporting multilingual ASR, VAD, punctuation restoration, speaker diarization, and emotion recognition.
 
 <a name="python-development tools"></a>
 #### Development Tools 


### PR DESCRIPTION
Adds [FunASR](https://github.com/modelscope/FunASR) to the Python Speech Recognition section.

FunASR is an industrial-grade open-source speech recognition toolkit with 19k+ GitHub stars. It supports multilingual ASR plus VAD, punctuation restoration, speaker diarization, and emotion recognition behind a Python API.

This PR is intentionally scoped to one README entry only. Current head `439d28cc` is rebased onto `master@75c821ba`; `git range-diff` confirms the one-commit patch is unchanged.

Validation:

- Exact diff is `README.md`, `+1/-0`
- The FunASR URL and entry are unique and remain inside the Python Speech Recognition section
- Both README entries added by the two intervening upstream commits are preserved
- `https://github.com/modelscope/FunASR` returns HTTP 200
- `git diff --check`
