### PR TITLE
Add Anneal to Go section

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [goro](https://github.com/aunum/goro) - A high-level machine learning library in the vein of Keras.
 * [gorse](https://github.com/zhenghaoz/gorse) - An offline recommender system backend based on collaborative filtering written in Go.
 * [therfoo](https://github.com/therfoo/therfoo) - An embedded deep learning library for Go.
+* [anneal](https://github.com/georgebuilds/anneal) - From-scratch Go port of tinygrad: a graph-rewrite ML compiler with reverse-mode autodiff and a WebGPU backend.
 * [neat](https://github.com/jinyeom/neat) - Plug-and-play, parallel Go framework for NeuroEvolution of Augmenting Topologies (NEAT). **[Deprecated]**
 * [go-pr](https://github.com/daviddengcn/go-pr) - Pattern recognition package in Go lang. **[Deprecated]**
 * [go-ml](https://github.com/alonsovidales/go_ml) - Linear / Logistic regression, Neural Networks, Collaborative Filtering and Gaussian Multivariate Distribution. **[Deprecated]**


### PR DESCRIPTION
Adds [anneal](https://github.com/georgebuilds/anneal), a from-scratch Go port of tinygrad (a graph-rewrite ML compiler with reverse-mode autodiff and a zero-CGO WebGPU/WGSL backend)

It is actively maintained.