### PR TITLE
Add Adaptive Reliability Layer — drift controller with delayed-label learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,7 @@ be
 * [AutoGluon](https://github.com/awslabs/autogluon): AutoML for Image, Text, Tabular, Time-Series, and MultiModal Data.
 * [PyBroker](https://github.com/edtechre/pybroker) - Algorithmic Trading with Machine Learning.
 * [Frouros](https://github.com/IFCA/frouros): Frouros is an open source Python library for drift detection in machine learning systems.
+* [Adaptive Reliability Layer](https://github.com/pberlizov/adaptive-reliability-layer): A bounded controller for production ML under distribution shift — detects drift, learns from delayed labels, and takes the smallest safe steering step to defer unnecessary retrains.
 * [CometML](https://github.com/comet-ml/comet-examples): The best-in-class MLOps platform with experiment tracking, model production monitoring, a model registry, and data lineage from training straight through to production.
 * [ClearML](https://github.com/clearml/clearml) -  Auto-Magical CI/CD to streamline your AI workload. Experiment Management, Data Management, Pipeline, Orchestration, Scheduling & Serving in one MLOps/LLMOps solution. 
 * [Okrolearn](https://github.com/Okerew/okrolearn): A python machine learning library created to combine powefull data analasys features with tensors and machine learning components, while maintaining support for other libraries.


### PR DESCRIPTION
Adding [Adaptive Reliability Layer](https://github.com/pberlizov/adaptive-reliability-layer) to the Python General-Purpose Machine Learning section, near the other drift/monitoring tools (Frouros, NannyML, Eurybia, Evidently).

**What it does:** sits between your inference pipeline and monitoring layer, detects distribution shift, learns from delayed revealed labels (e.g. fraud chargebacks arriving weeks after inference), and takes the smallest bounded steering step to stabilize the model — deferring unnecessary full retrains.

**Why it fits here:** complements the existing drift detection tools with an active controller layer rather than just monitoring/alerting. Benchmarked on public fraud streams (ULB, IEEE-CIS, PaySim) and NASA CMAPSS predictive maintenance data.

- PyPI: `pip install adaptive-reliability-layer`
- Python 3.10+, source-available under BUSL-1.1