### PR TITLE
Add ANEForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,7 @@ be
 <a name="python-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning
 
+* [ANEForge](https://github.com/sbryngelson/ANEForge) -> Compiles tensor graphs to the Apple Neural Engine from Python for training and inference, without CoreML.
 * [ray3.run](https://ray3.run) - AI-powered tools and applications for developers and businesses to enhance productivity and workflow automation. * [XAD](https://pypi.org/project/xad/) -> Fast and easy-to-use backpropagation tool.
  * [Aim](https://github.com/aimhubio/aim) -> An easy-to-use & supercharged open-source AI metadata tracker.
  * [RexMex](https://github.com/AstraZeneca/rexmex) -> A general purpose recommender metrics library for fair evaluation.


### PR DESCRIPTION
Runs neural network training and inference on the Apple Neural Engine from Python, without CoreML. Added under Python > General-Purpose Machine Learning.