### PR TITLE
Add Meridian Institute of AI to free courses

### DIFF
--- a/courses.md
+++ b/courses.md
@@ -2,6 +2,7 @@ The following is a list of free or paid online courses on machine learning, stat
 
 ## Machine-Learning / Data Mining
 
+* [Meridian Institute of AI](https://meridianinstituteai.com) - 20 free AI courses with certificates. Covers foundations, prompt engineering, machine learning, AI agents, and domain applications in finance, law, healthcare, and cybersecurity - free
 * [System Designer - ML Systems](https://systemdesigner.net/ml-systems) - Interactive learning platform for ML systems and MLOps with 28 lessons on training pipelines, model serving, feature stores, and monitoring. Includes AI tutor, whiteboards, quizzes, and hands-on projects - free
 * [System Designer - GenAI](https://systemdesigner.net/genai) - Interactive learning platform for GenAI and LLMs with 32 lessons on RAG systems, vector databases, agentic AI, and deployment. Includes AI tutor, whiteboards, quizzes, and projects - free
 * [Artificial Intelligence (Columbia University)](https://www.edx.org/course/artificial-intelligence-ai-columbiax-csmm-101x-0) - free


### PR DESCRIPTION
## What

Adding [Meridian Institute of AI](https://meridianinstituteai.com) to the Machine-Learning / Data Mining section of .

## Why

Meridian is a free online AI education platform with 20 courses and verifiable certificates. Courses cover foundations, prompt engineering, machine learning, AI agents, and domain applications in finance, law, healthcare, and cybersecurity. All free to start.

## Entry

