### PR TITLE
Add AI Weekly to the Newsletters section

### DIFF
--- a/blogs.md
+++ b/blogs.md
@@ -23,6 +23,7 @@ Podcasts
 * [AI Stories Podcast](https://www.youtube.com/@aistoriespodcast)
 
 Newsletters
+* [AI Weekly](https://aiweekly.co/). An independent AI news newsletter, published 3x/week since 2015 to 44,000+ professionals — the few AI stories that matter, plus the AI Weekly Index, a quarterly State-of-AI recap, a Who's-Who-of-AI graph (2,335 figures), and an 11-year archive.
 -----------
 
 * [AI Digest](https://aidigest.net/). A weekly newsletter to keep up to date with AI, machine learning, and data science. [Archive](https://aidigest.net/digests).


### PR DESCRIPTION
Adds AI Weekly (https://aiweekly.co) to the Newsletters section of blogs.md. It's an independent AI news newsletter that has shipped 3x/week since 2015 to 44,000+ professionals, fitting alongside existing entries like The Batch and AI Digest. (Distinct from ai-weekly.ai, weeklyreport.ai, and the defunct VentureBeat AI Weekly.)