### PR TITLE
Add zvec to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1915,6 +1915,7 @@ be
 * [HyperAgency](https://github.com/vuics/h9y) - agentic AI operating system (h9y.ai) that replaces brittle/fragmented automations with long-lived, self-improving systems. Open-source, self-hosted/cloud, visual workflow, omni-channel, decentralized, extensible.
 * [Bread Dataset Viewer](https://github.com/Bread-Technologies/mle_vscode_extension) - A VS Code extension for viewing and exploring large machine learning datasets (CSV, JSON, Parquet, etc.) directly within the editor without VS Code crashing in a clean UI.
 * [Bread WandB Viewer](https://github.com/Bread-Technologies/bread_wandb_viewer_extension) - A VS Code extension to view Weights & Biases experiments, logs, and artifacts within the IDE, eliminating the need to switch to the web UI and keeping data private.
+* [zvec](https://github.com/alibaba/zvec) - An embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
 
 <a name="books"></a>
 ## Books


### PR DESCRIPTION
## Project: [zvec](https://github.com/alibaba/zvec)

Zvec is an open-source embedded vector database by Alibaba Tongyi Lab — the SQLite of vector databases. It runs in-process with zero external dependencies, just `pip install zvec`.

### Why it fits here

- Similar to Chroma, Qdrant, Milvus, and Weaviate already listed in this section
- Embedded/in-process architecture — no server, no daemon, zero-config
- 12,500+ GitHub stars, actively maintained (latest: v0.5.1, June 2026)
- Built on Alibaba production-proven Proxima engine
- Python SDK (`pip install zvec`) plus Go, Rust, and Dart bindings