### PR TITLE
Add sklearn-java to Java section

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Weka](https://www.cs.waikato.ac.nz/ml/weka/) - Weka is a collection of machine learning algorithms for data mining tasks.
 * [LBJava](https://github.com/CogComp/lbjava) - Learning Based Java is a modelling language for the rapid development of software systems, offers a convenient, declarative syntax for classifier and constraint definition directly in terms of the objects in the programmer's application.
 * [knn-java-library](https://github.com/felipexw/knn-java-library) - Just a simple implementation of K-Nearest Neighbors algorithm using with a bunch of similarity measures.
+* [sklearn-java](https://github.com/kVeyra/sklearn-java) - Pure Java reimplementation of scikit-learn's ML API with 1e-8 numerical accuracy, covering 72+ algorithms.
 
 <a name="java-speech-recognition"></a>
 #### Speech Recognition


### PR DESCRIPTION
## Description

Adds [sklearn-java](https://github.com/kVeyra/sklearn-java) to the Java > General-Purpose Machine Learning section — a pure Java reimplementation of scikit-learn's machine learning API.

- Apache 2.0 license
- 72+ sklearn algorithms implemented (linear models, trees, ensembles, SVM, preprocessing, metrics, model selection, clustering, naive bayes, neighbors)
- API mirrors sklearn 1:1
- 190+ JUnit 5 tests, numerical accuracy validated to 1e-8 against Python sklearn

Let me know if any changes are needed!