### PR TITLE
Add altor-vec to JavaScript General-Purpose ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 * [Brain.js](https://github.com/BrainJS/brain.js) - Neural networks in JavaScript - continued community fork of [Brain](https://github.com/harthur/brain).
 * [Bayesian-Bandit](https://github.com/omphalos/bayesian-bandit.js) - Bayesian bandit implementation for Node and the browser. **[Deprecated]**
 * [Synaptic](https://github.com/cazala/synaptic) - Architecture-free neural network library for Node.js and the browser.
+* [altor-vec](https://github.com/altor-lab/altor-vec) - In-browser HNSW vector similarity search engine compiled to 54KB WASM. Semantic search for JavaScript apps with no server required.
 * [kNear](https://github.com/NathanEpstein/kNear) - JavaScript implementation of the k nearest neighbors algorithm for supervised learning.
 * [NeuralN](https://github.com/totemstech/neuraln) - C++ Neural Network library for Node.js. It has advantage on large dataset and multi-threaded training. **[Deprecated]**
 * [kalman](https://github.com/itamarwe/kalman) - Kalman filter for JavaScript. **[Deprecated]**


### PR DESCRIPTION
## altor-vec

[altor-vec](https://github.com/altor-lab/altor-vec) is an HNSW vector similarity search engine written in Rust that compiles to 54KB of WebAssembly and runs entirely in the browser.

**Fits the JavaScript General-Purpose ML section because:**
- Pure JavaScript/WASM: works in browser and Node.js
- Implements HNSW (the same algorithm as Pinecone, Qdrant, pgvector)
- Sub-millisecond search: 0.6ms p95 for 10K vectors in Chrome
- No server, no API keys, no per-query cost
- Works with any float embeddings (Transformers.js, OpenAI, Cohere)
- MIT licensed, npm install altor-vec
- Docs: https://altorlab.dev