### PR TITLE
Add autobatcher to Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,7 @@ be
 * [Opik](https://github.com/comet-ml/opik): Evaluate, trace, test, and ship LLM applications across your dev and production lifecycles.
 * [pyclugen](https://github.com/clugen/pyclugen) - Multidimensional cluster generation in Python.
 * [mlforgex](https://github.com/dhgefergfefruiwefhjhcduc/ML_Forgex) - Lightweight ML utility for automated training, evaluation, and prediction with CLI and Python API support.
+* [autobatcher](https://github.com/doublewordai/autobatcher) - Drop-in AsyncOpenAI replacement that transparently batches requests via the Batch API for cheaper LLM inference.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Adds [autobatcher](https://github.com/doublewordai/autobatcher), an open-source Python library: a drop-in `AsyncOpenAI` replacement that transparently batches requests via the Batch API for cheaper LLM inference.

- Placed in Python -> General-Purpose Machine Learning, appended at the end of the subsection following the existing chronological ordering.
- Format matches neighboring entries (`* [name](url) - description.`).
- Single entry, one line changed. Link resolves.

Happy to adjust placement or wording if preferred.