### PR TITLE
Add AI Engineering Hub — free agentic-AI tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1919,6 +1919,7 @@ be
 <a name="books"></a>
 ## Books
 
+* [AI Engineering Hub](https://github.com/CodeGero/ai-engineering-hub) - Free, research-backed tutorials for building with AI agents (Ollama, LangGraph, AutoGen, MCP, RAG, prompt engineering). Runnable, local-first code. MIT-licensed.
 * [Distributed Machine Learning Patterns](https://github.com/terrytangyuan/distributed-ml-patterns)  - This book teaches you how to take machine learning models from your personal laptop to large distributed clusters. You’ll explore key concepts and patterns behind successful distributed machine learning systems, and learn technologies like TensorFlow, Kubernetes, Kubeflow, and Argo Workflows directly from a key maintainer and contributor, with real-world scenarios and hands-on projects.
 * [Grokking Machine Learning](https://www.manning.com/books/grokking-machine-learning) - Grokking Machine Learning teaches you how to apply ML to your projects using only standard Python code and high school-level math.
 * [Machine Learning Bookcamp](https://www.manning.com/books/machine-learning-bookcamp) - Learn the essentials of machine learning by completing a carefully designed set of real-world projects.


### PR DESCRIPTION
Free, MIT-licensed tutorial hub for building with AI agents: Ollama (local, private inference), a from-scratch ReAct agent, LangGraph, AutoGen, MCP servers, RAG with LlamaIndex, prompt engineering, deployment, and agent skills. Every example is runnable and local-first. Added under Books as a learning resource.