### PR TITLE
adding NoTorch to the list: neural networks in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Further resources:
 * [cONNXr](https://github.com/alrevuelta/cONNXr) - An `ONNX` runtime written in pure C (99) with zero dependencies focused on small embedded devices. Run inference on your machine learning models no matter which framework you train it with. Easy to install and compiles everywhere, even in very old devices.
 * [libonnx](https://github.com/xboot/libonnx) - A lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 * [onnx-c](https://github.com/onnx/onnx-c) - A lightweight C library for ONNX model inference, optimized for performance and portability across platforms.
+* [notorch](https://github.com/ariannamethod/notorch) - A neural network framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 
 <a name="c-computer-vision"></a>

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Further resources:
 * [cONNXr](https://github.com/alrevuelta/cONNXr) - An `ONNX` runtime written in pure C (99) with zero dependencies focused on small embedded devices. Run inference on your machine learning models no matter which framework you train it with. Easy to install and compiles everywhere, even in very old devices.
 * [libonnx](https://github.com/xboot/libonnx) - A lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 * [onnx-c](https://github.com/onnx/onnx-c) - A lightweight C library for ONNX model inference, optimized for performance and portability across platforms.
-* [notorch](https://github.com/ariannamethod/notorch) - A neural network framework in pure C: training and inference, no dependencies.
+* [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 
 <a name="c-computer-vision"></a>


### PR DESCRIPTION
NoTorch is self-contained neural network framework written in C. no pip and no runtime dependencies. it has BPE tokenizer, tape-based autograd, an in-house adaptive optimizer, BLAS acceleration (OpenBLAS, Apple Accelerate, plus its own AVX2 SIMD, CUDA and Metal backends). it trains models and inference them, loads pre-quantized GGUF's

lands in C > General-Purpose Machine Learning, next to onnx-c. 