### PR TITLE
Add light-ocr to C++ computer vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Further resources:
 
 * [DLib](http://dlib.net/imaging.html) - DLib has C++ and Python interfaces for face detection and training general object detectors.
 * [EBLearn](http://eblearn.sourceforge.net/) - Eblearn is an object-oriented C++ library that implements various machine learning models **[Deprecated]**
+* [light-ocr](https://github.com/arcships/light-ocr) - Fast, offline OCR library for C++ and Node.js using PP-OCRv6, with bundled cross-platform runtimes.
 * [OpenCV](https://opencv.org) - OpenCV has C++, C, Python, Java and MATLAB interfaces and supports Windows, Linux, Android and Mac OS.
 * [VIGRA](https://github.com/ukoethe/vigra) - VIGRA is a genertic cross-platform C++ computer vision and machine learning library for volumes of arbitrary dimensionality with Python bindings.
 * [Openpose](https://github.com/CMU-Perceptual-Computing-Lab/openpose) - A real-time multi-person keypoint detection library for body, face, hands, and foot estimation


### PR DESCRIPTION
Adds light-ocr to the C++ Computer Vision section.

light-ocr is an Apache-2.0 licensed offline OCR library for C++ and Node.js. It runs PP-OCRv6 through bundled cross-platform runtimes, so applications do not require a Python environment at runtime.

The entry follows the existing one-line project format, and the Markdown diff passes `git diff --check`.