### PR TITLE
Add Leanpass autodiff library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,7 @@ be
 * [stacked_generalization](https://github.com/fukatani/stacked_generalization) - Implementation of machine learning stacking technique as a handy library in Python.
 * [modAL](https://github.com/modAL-python/modAL) - A modular active learning framework for Python, built on top of scikit-learn.
 * [Cogitare](https://github.com/cogitare-ai/cogitare): A Modern, Fast, and Modular Deep Learning and Machine Learning framework for Python.
+* [Leanpass](https://github.com/Terminay/LeanPass) - A lightweight, NumPy-only autodiff library for small ML projects and learning how backpropagation works. It is 700x times lighter than Pytorch and 900x times lighter than TensorFlow.
 * [Parris](https://github.com/jgreenemi/Parris) - Parris, the automated infrastructure setup tool for machine learning algorithms.
 * [neonrvm](https://github.com/siavashserver/neonrvm) - neonrvm is an open source machine learning library based on RVM technique. It's written in C programming language and comes with Python programming language bindings.
 * [Turi Create](https://github.com/apple/turicreate) - Machine learning from Apple. Turi Create simplifies the development of custom machine learning models. You don't have to be a machine learning expert to add recommendations, object detection, image classification, image similarity or activity classification to your app.


### PR DESCRIPTION
### Summary

Adding LeanPass, a small NumPy-only reverse-mode autodiff library aimed at learning how backpropagation works. MIT licensed, includes tests and a gradient-checking utility.

Useful for educational purposes, quick prototyping, or toy models where the full weight of PyTorch or TensorFlow isn't needed.

### Ethnicity

The repo is currently being maintained and is on version `v0.1.3`. Here is the link for verification
 [LeanPass URL](https://github.com/Terminay/LeanPass)