### PR TITLE
Add Cortexa to Tools/Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Further resources:
 - [Misc](#tools-misc)
 
 
+
 [Credits](#credits)
 
 <!-- /MarkdownTOC -->
@@ -1918,7 +1919,7 @@ be
 * [HyperAgency](https://github.com/vuics/h9y) - agentic AI operating system (h9y.ai) that replaces brittle/fragmented automations with long-lived, self-improving systems. Open-source, self-hosted/cloud, visual workflow, omni-channel, decentralized, extensible.
 * [Bread Dataset Viewer](https://github.com/Bread-Technologies/mle_vscode_extension) - A VS Code extension for viewing and exploring large machine learning datasets (CSV, JSON, Parquet, etc.) directly within the editor without VS Code crashing in a clean UI.
 * [Bread WandB Viewer](https://github.com/Bread-Technologies/bread_wandb_viewer_extension) - A VS Code extension to view Weights & Biases experiments, logs, and artifacts within the IDE, eliminating the need to switch to the web UI and keeping data private.
-
+* [Cortexa](https://automata-index.vercel.app) - Free, open-access search engine for robotics, ML, and AI research papers (arXiv, MDPI, IEEE OA).
 <a name="books"></a>
 ## Books
 


### PR DESCRIPTION
Adding Cortexa, a free open-access research paper search engine for
robotics, ML, and AI (aggregating arXiv, MDPI, and individually
Creative-Commons-verified IEEE articles) — thought it'd be a useful
addition to this section.