### PR TITLE
Add ragleap-rag to Python NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,7 @@ be
 <a name="python-natural-language-processing"></a>
 #### Natural Language Processing
 
+* [ragleap-rag](https://github.com/antonyrag/ragleap-core) - CPU-only RAG (Retrieval-Augmented Generation) library with a 23MB ONNX reranker, 6 vector backends, and 8 embedding providers.
 * [pkuseg-python](https://github.com/lancopku/pkuseg-python) - A better version of Jieba, developed by Peking University.
 * [NLTK](https://www.nltk.org/) - A leading platform for building Python programs to work with human language data.
 * [Pattern](https://github.com/clips/pattern) - A web mining module for the Python programming language. It has tools for natural language processing, machine learning, among others.


### PR DESCRIPTION
Adds ragleap-rag — an open-source Python RAG (Retrieval-Augmented
Generation) library focused on running without a GPU. The reranker
uses a 23MB quantized ONNX model instead of the usual 2GB+ torch/CUDA
stack.

- 6 vector backends (pgvector, FAISS live-verified; Pinecone, Weaviate,
  Qdrant, Milvus code-complete)
- 8 embedding providers, 12+ generation providers with automatic fallback
- Real per-call cost tracking with monthly budgets
- 238 tests, CI on every PR

pip install ragleap-rag
https://pypi.org/project/ragleap-rag/