### PR TITLE
Add PhilanthroPy (scikit-learn native fundraising analytics toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ be
 * [prophet](https://facebook.github.io/prophet/) - Fast and automated time series forecasting framework by Facebook.
 * [skforecast](https://github.com/skforecast/skforecast) - Python library for time series forecasting using machine learning models. It works with any regressor compatible with the scikit-learn API, including popular options like LightGBM, XGBoost, CatBoost, Keras, and many others.
 * [Feature-engine](https://github.com/feature-engine/feature_engine) - Open source library with an exhaustive battery of feature engineering and selection methods based on pandas and scikit-learn.
+* [PhilanthroPy](https://github.com/PhilanthroPy-Project/PhilanthroPy) - A scikit-learn native toolkit for nonprofit and academic-medical-center fundraising analytics: leakage-safe donor propensity, lapse, planned-giving, wealth-screening and revenue-forecasting estimators.
 * [gensim](https://github.com/RaRe-Technologies/gensim) - Topic Modelling for Humans.
 * [Gower Express](https://github.com/momonga-ml/gower-express.git) - The Fastest Gower Distance Implementation for Python. GPU-accelerated similarity matching for mixed data types, 15-25% faster than alternatives with production-ready reliability.
 * [tweetopic](https://centre-for-humanities-computing.github.io/tweetopic/) - Blazing fast short-text-topic-modelling for Python.


### PR DESCRIPTION
One-line addition under Python > General-Purpose Machine Learning: [PhilanthroPy](https://github.com/PhilanthroPy-Project/PhilanthroPy), a scikit-learn native toolkit for nonprofit and academic-medical-center fundraising analytics (leakage-safe donor propensity, lapse, planned-giving, wealth-screening, revenue-forecasting estimators; passes `check_estimator`).