### PR TITLE
Add Fair Code to Python > Misc Scripts / iPython Notebooks / Codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1460,6 +1460,7 @@ be
 * [Heart_Disease-Prediction](https://github.com/ShivamChoudhary17/Heart_Disease) - Given clinical parameters about a patient, can we predict whether or not they have heart disease?
 * [Flight Fare Prediction](https://github.com/ShivamChoudhary17/Flight_Fare_Prediction) - This basically to gauge the understanding of Machine Learning Workflow and Regression technique in specific.
 * [Keras Tuner](https://github.com/keras-team/keras-tuner) - An easy-to-use, scalable hyperparameter optimization framework that solves the pain points of hyperparameter search.
+* [Fair Code](https://github.com/yakew7/Fair-Code) - Jupyter notebooks and a benchmark harness that audit real-world-style AI systems (COMPAS, hiring, lending, insurance, welfare, hospital readmission, tenant screening) for algorithmic bias, pairing a biased baseline with a mitigated version and measured before/after fairness metrics.
 
 
 


### PR DESCRIPTION
I'm the author of Fair Code and am submitting it for inclusion in this list.

Fair Code (https://github.com/yakew7/Fair-Code, site: thefaircode.xyz) is an open-source project that audits real-world-style AI systems for algorithmic bias across 7 domains: criminal justice (COMPAS), hiring, lending, insurance, welfare, hospital readmission, and tenant screening. Each audit ships a biased baseline model alongside a mitigated version, with measured before/after fairness metrics, Jupyter notebooks, a benchmark harness, and a client-side dataset bias profiler. It's MIT licensed, with 43 stars, 21 forks, and 15 outside contributors.

It fits the Python > Misc Scripts / iPython Notebooks / Codebases section as a collection of Jupyter notebooks and Python scripts demonstrating applied ML techniques (here, fairness auditing and bias mitigation) end-to-end, consistent with the other notebook-based, educational codebases already listed there.