### PR TITLE
Add qwen3.8-27b-in-c to C projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Further resources:
 * [onnx-c](https://github.com/onnx/onnx-c) - A lightweight C library for ONNX model inference, optimized for performance and portability across platforms.
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
+* [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
 
 <a name="c-computer-vision"></a>
 #### Computer Vision


### PR DESCRIPTION
Adds [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) to the C / General-Purpose section.

The project is a native C inference engine for running Qwen3.8-27B locally on a single laptop CPU. It loads GGUF weights directly, implements the model graph and Gated DeltaNet state, and includes low-bit CPU kernels, tokenizer, sampling, and multi-turn chat. The IQ1_M path has been tested under an 8 GB memory limit.

The new entry follows the existing one-line project-description format and changes only README.md.