### PR TITLE
Add Thimble to C / General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
+* [Thimble](https://github.com/nikshepsvn/thimble) - A 48M-parameter grammar-constrained tool-calling model with a single-file, dependency-free C inference engine (int8, 48 MB weights, byte-verified against the reference stack); output is always schema-valid JSON.
 
 <a name="c-computer-vision"></a>
 #### Computer Vision


### PR DESCRIPTION
Adds [Thimble](https://github.com/nikshepsvn/thimble): a 48M-parameter tool-calling-only language model whose JSON output is grammar-constrained (structure and argument keys come from the user's schemas, so output is always parseable), shipping with a single-file, dependency-free C inference engine — 48 MB int8 weights, ~20 ms load, byte-identical output to the PyTorch reference on 100/100 checked eval rows. MIT licensed, weights on Hugging Face, full training pipeline and eval harness in the repo.

Placed next to the other pure-C inference engines in the section (cONNXr, libonnx, qwen3.8-27b-in-c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LsYfVD9BxJWE4Uz8NCAu8