### PR TITLE
Add me_fasttext to C++ NLP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Further resources:
 * [frog](https://github.com/LanguageMachines/frog) - Memory-based NLP suite developed for Dutch: PoS tagger, lemmatiser, dependency parser, NER, shallow parser, morphological analyzer.
 * [libfolia](https://github.com/LanguageMachines/libfolia) - C++ library for the [FoLiA format](https://proycon.github.io/folia/)
 * [MeTA](https://github.com/meta-toolkit/meta) - [MeTA : ModErn Text Analysis](https://meta-toolkit.org/) is a C++ Data Sciences Toolkit that facilitates mining big text data.
+* [me_fasttext](https://github.com/initial-d/me_fasttext) - Memory-efficient FastText-derived C++ prototype with exact trie-based subword ids and compact mmap serving.
 * [MIT Information Extraction Toolkit](https://github.com/mit-nlp/MITIE) - C, C++, and Python tools for named entity recognition and relation extraction
 * [ucto](https://github.com/LanguageMachines/ucto) - Unicode-aware regular-expression based tokenizer for various languages. Tool and C++ library. Supports FoLiA format.
 * [SentencePiece](https://github.com/google/sentencepiece) - A C++ library for unsupervised text tokenization and detokenization, widely used in modern NLP models.


### PR DESCRIPTION
## What

Adds `me_fasttext` to the C++ Natural Language Processing section.

## Why

It is a FastText-derived C++ research prototype for memory-sensitive word/subword embeddings. The project replaces hash-bucketed character n-gram ids with exact trie-based ids and exports a compact mmap serving index for large-vocabulary NLP.

## Disclosure

I maintain the project. I kept the addition to one concise line and placed it in the C++ NLP section because it is directly related to FastText-style NLP infrastructure.