### PR TITLE
Add qwen3.8-flash-next-in-c to C projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
+* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - A native C inference engine for Qwen3.8-Flash-Next (125B-A6B plus 51B PLE) on a single laptop CPU, with exact batch-4 verification throughput reaching nearly 10 token positions per second on tested hardware.
 * [deepseek-v4-flash-0731-in-c](https://github.com/shyringo/deepseek-v4-flash-0731-in-c) - A native C CPU inference engine for running the 284B-A13B DeepSeek-V4-Flash-0731 on one laptop, reaching up to 1.12 token/s on tested hardware while streaming the 167 GB checkpoint from disk with a tested 8 GB memory path and no GPU or Python.
 
 <a name="c-computer-vision"></a>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
-* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the strongest model under 200B on a single laptop CPU with native C and near-10 token/s exact batch throughput.
+* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the best model under 200B on a single laptop CPU with native C and near-10 token/s exact batch throughput.
 * [deepseek-v4-flash-0731-in-c](https://github.com/shyringo/deepseek-v4-flash-0731-in-c) - A native C CPU inference engine for running the 284B-A13B DeepSeek-V4-Flash-0731 on one laptop, reaching up to 1.12 token/s on tested hardware while streaming the 167 GB checkpoint from disk with a tested 8 GB memory path and no GPU or Python.
 
 <a name="c-computer-vision"></a>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
-* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - A native C inference engine for Qwen3.8-Flash-Next (125B-A6B plus 51B PLE) on a single laptop CPU, with exact batch-4 verification throughput reaching nearly 10 token positions per second on tested hardware.
+* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the strongest model under 200B on a single laptop CPU with native C and near-10 token/s exact batch throughput.
 * [deepseek-v4-flash-0731-in-c](https://github.com/shyringo/deepseek-v4-flash-0731-in-c) - A native C CPU inference engine for running the 284B-A13B DeepSeek-V4-Flash-0731 on one laptop, reaching up to 1.12 token/s on tested hardware while streaming the 167 GB checkpoint from disk with a tested 8 GB memory path and no GPU or Python.
 
 <a name="c-computer-vision"></a>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
-* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the best model under 200B on a single laptop CPU with native C, a 12 GB practical minimum, and near-10 token/s exact batch throughput.
+* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the best model under 200B on a single laptop CPU with native C, an automatic 8 GB path, and near-10 token/s exact batch throughput.
 * [deepseek-v4-flash-0731-in-c](https://github.com/shyringo/deepseek-v4-flash-0731-in-c) - A native C CPU inference engine for running the 284B-A13B DeepSeek-V4-Flash-0731 on one laptop, reaching up to 1.12 token/s on tested hardware while streaming the 167 GB checkpoint from disk with a tested 8 GB memory path and no GPU or Python.
 
 <a name="c-computer-vision"></a>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Further resources:
 * [notorch](https://github.com/ariannamethod/notorch) - Neural networks framework in pure C: training and inference, no dependencies.
 * [qsmm](http://qsmm.org) - A C library implementing the rudiments of a toolchain for working with adaptive probabilistic assembler programs.
 * [qwen3.8-27b-in-c](https://github.com/shyringo/qwen3.8-27b-in-c) - A native C inference engine for running Qwen3.8-27B locally on a single laptop CPU, with direct GGUF loading and a tested 8 GB memory path.
-* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the best model under 200B on a single laptop CPU with native C and near-10 token/s exact batch throughput.
+* [qwen3.8-flash-next-in-c](https://github.com/shyringo/qwen3.8-flash-next-in-c) - Run the best model under 200B on a single laptop CPU with native C, a 12 GB practical minimum, and near-10 token/s exact batch throughput.
 * [deepseek-v4-flash-0731-in-c](https://github.com/shyringo/deepseek-v4-flash-0731-in-c) - A native C CPU inference engine for running the 284B-A13B DeepSeek-V4-Flash-0731 on one laptop, reaching up to 1.12 token/s on tested hardware while streaming the 167 GB checkpoint from disk with a tested 8 GB memory path and no GPU or Python.
 
 <a name="c-computer-vision"></a>


### PR DESCRIPTION
Adds qwen3.8-flash-next-in-c to the C general-purpose machine-learning section.

The project runs Qwen3.8-Flash-Next on a single laptop CPU with an automatic 8 GB minimum path. Its native C runtime provides terminal chat, an OpenAI-compatible local API, and exact batch throughput measured at 9.89 positions/s on the reference i5-1340P laptop. An independent AMD 7840HS report reached 13.261 positions/s and completed a 3,355-token generation at 2.15 token/s.

Repository: https://github.com/shyringo/qwen3.8-flash-next-in-c
Independent benchmark: https://github.com/shyringo/qwen3.8-flash-next-in-c/discussions/1#discussioncomment-18328126