### PR TITLE
Add OrcaReplay to Tools / Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1958,6 +1958,8 @@ be
 * [Bread Dataset Viewer](https://github.com/Bread-Technologies/mle_vscode_extension) - A VS Code extension for viewing and exploring large machine learning datasets (CSV, JSON, Parquet, etc.) directly within the editor without VS Code crashing in a clean UI.
 * [Bread WandB Viewer](https://github.com/Bread-Technologies/bread_wandb_viewer_extension) - A VS Code extension to view Weights & Biases experiments, logs, and artifacts within the IDE, eliminating the need to switch to the web UI and keeping data private.
 * [Cortexa](https://automata-index.vercel.app) - Free, open-access search engine for robotics, ML, and AI research papers (arXiv, MDPI, IEEE OA).
+* [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Record, replay and fork runs of coding agents. Captures below the harness so model traffic, shell exit codes, per-turn file changes and MCP calls share one timeline, then replays the run offline with the network off or forks it from a checkpoint onto a different model.
+
 <a name="books"></a>
 ## Books
 


### PR DESCRIPTION
Adds OrcaReplay to **Tools → Misc**.

`Localforge` is already in that bucket, so tooling for working with coding agents appears to be in scope there. OrcaReplay is the debugging side of it: it records a coding-agent run at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The recording then replays offline with the network off — reproducing the run byte-for-byte on another machine — or forks from a chosen checkpoint onto a different model, with earlier turns still served from the recording so both models see identical context.

Apache-2.0, on npm as `orcareplay` (Node 20+), 12 packages published with sigstore provenance. Works with Claude Code, Codex, opencode, Qwen Code, Cursor and others.

Placed at the end of the existing `Misc` bucket, so no new section. Worth saying plainly: the repository is nine days old with 150 stars, and this is tooling for using LLM agents rather than a machine-learning library — if `Misc` is narrower than Localforge suggests, that is a fair reason to decline.
