### PR TITLE
docs: add hands-on ML book recommendation

### DIFF
--- a/books.md
+++ b/books.md
@@ -155,3 +155,5 @@ The following is a list of free and/or open source books on machine learning, st
 * [Calculus Made Easy](https://github.com/lahorekid/Calculus/blob/master/Calculus%20Made%20Easy.pdf)
 * [calculus by ron larson](https://www.pdfdrive.com/calculus-e183995561.html)
 * [Active Calculus by Matt Boelkins](https://scholarworks.gvsu.edu/books/20/)
+
+* [Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow](https://www.oreilly.com/library/view/hands-on-machine-learning/9781098125967/) - Aurélien Géron


### PR DESCRIPTION
Adds Aurélien Géron's "Hands-On Machine Learning" book to the books list.