### PR TITLE
Add GPUMesh to Python General-Purpose Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,6 +1370,7 @@ be
 * [pyclugen](https://github.com/clugen/pyclugen) - Multidimensional cluster generation in Python.
 * [mlforgex](https://github.com/dhgefergfefruiwefhjhcduc/ML_Forgex) - Lightweight ML utility for automated training, evaluation, and prediction with CLI and Python API support.
 * [autobatcher](https://github.com/doublewordai/autobatcher) - Drop-in AsyncOpenAI replacement that transparently batches requests via the Batch API for cheaper LLM inference.
+* [GPUMesh](https://github.com/K4-LABS/gpumesh) - Borrow your friends' GPUs across your LAN with a Python decorator and CLI pool for parallel sweeps and training.
 
 <a name="python-data-analysis--data-visualization"></a>
 #### Data Analysis / Data Visualization


### PR DESCRIPTION
Add GPUMesh under Python / General-Purpose Machine Learning.

GPUMesh lets you borrow GPUs across your LAN with a Python decorator and CLI pool. Good fit for parallel sweeps and small training jobs without setting up infra. Apache-2.0, pip plus Docker, docs in repo.

Entry added at the end of the Python General-Purpose section, one line, matching surrounding format.

Project: https://github.com/K4-LABS/gpumesh
Community chat if you want to reach me: https://discord.gg/axQwpyqZA

I am the maintainer submitting my own project. Happy to adjust wording or placement.
