### PR TITLE
Add yasbd-lib to Python NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,7 @@ be
 * [Transformers](https://github.com/huggingface/transformers) - A deep learning library containing thousands of pre-trained models on different tasks. The goto place for anything related to Large Language Models.
 * [TextCL](https://github.com/alinapetukhova/textcl) - Text preprocessing package for use in NLP tasks.
 * [VeritasGraph](https://github.com/bibinprathap/VeritasGraph) - Enterprise-Grade Graph RAG for Secure, On-Premise AI with Verifiable Attribution.
+* [yasbd-lib](https://github.com/speedyk-005/yasbd-lib) - High-accuracy, rule-based sentence boundary detector (SBD) with drop-in pysbd adapter, streaming APIs, CLI, and a spaCy component across 39+ languages.
 
 <a name="python-general-purpose-machine-learning"></a>
 #### General-Purpose Machine Learning


### PR DESCRIPTION
I have added **[yasbd-lib](https://github.com/speedyk-005/yasbd-lib)** (**Y**et **A**nother **S**entence **B**oundary **D**etector) to the Python NLP section of the README.

> It is a high-accuracy, rule-based sentence boundary detector (SBD) for Python that handles abbreviations, initials, decimals, ellipses, and multilingual punctuation without naive split-on-punctuation failures. 

Related to #1406
